### PR TITLE
Replace mutating `set_size` and `with_size` with view API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This release adds **PaCo** (Coron & Seuré, [ePrint 2025/886](https://eprint.iac
 ### `poulpy-hal`
 - Add `ModulePlanCache` — a per-`Module`, heterogeneous, typed cache of immutable plan families (keyed by a logical ZST type via `TypeId`) with a closure-based `with_or_create` accessor that initializes each entry exactly once under concurrency — plus the `unsafe trait ModulePlanCacheProvider` implemented by backend handles that own the cache, keeping plan location and destruction order a backend concern (important for device-resource plans). This generalizes the FFT-table cache previously private to `poulpy-cpu-ref` into a neutral HAL ownership contract.
 - **Breaking:** `Backend` gains two required methods, `copy_view_to_host` and `copy_host_to_view`, for byte transfers between arena views (not owned buffers) and host slices; device backends implement them as device↔host copies. External `Backend` implementations must add both.
+- **Breaking:** remove the public `set_size` / layout-level `with_size` resizing API from `VecZnx`, `VecZnxDft`, and `VecZnxBig`. Temporary DFT compute widths now use scoped HAL `VecZnxDftBackendMut::with_size_mut` views, so owned object metadata is not mutated and restored around kernels.
 - Re-document `Module` as a multi-ring execution context: `n()` is now specified as the **maximum** ring degree and the new alias `max_n()` makes dimension-aware call sites explicit, so one module can serve every power-of-two sub-dimension (used by the new encoding plan sets).
 
 ### `poulpy-core`

--- a/poulpy-ckks/src/test_suite/paco_parallel.rs
+++ b/poulpy-ckks/src/test_suite/paco_parallel.rs
@@ -250,24 +250,6 @@ pub fn test_paco_parallel_bootstrap<BE, F, E>(
     assert!(error.to_string().contains("scratch bytes"), "unexpected error: {error:#}");
     assert_ciphertext_unchanged::<BE>(&before, &rejected);
 
-    let mut truncated_input = ct_in.clone();
-    truncated_input.data_mut().set_size(0);
-    let before = rejected.to_host_owned::<BE>();
-    let error = module
-        .ckks_paco_bootstrap_direct_into::<_, _>(&mut rejected, &truncated_input, &ctx, &keys, KAPPA, &mut scratch.borrow())
-        .expect_err("an input with truncated active storage must be rejected");
-    assert!(error.to_string().contains("active limbs"), "unexpected error: {error:#}");
-    assert_ciphertext_unchanged::<BE>(&before, &rejected);
-
-    let mut truncated_output = module.ckks_ciphertext_alloc(ctx.base2k(), k_out);
-    truncated_output.data_mut().set_size(0);
-    let before = truncated_output.to_host_owned::<BE>();
-    let error = module
-        .ckks_paco_bootstrap_direct_into::<_, _>(&mut truncated_output, &ct_in, &ctx, &keys, KAPPA, &mut scratch.borrow())
-        .expect_err("an output with truncated active storage must be rejected");
-    assert!(error.to_string().contains("active limbs"), "unexpected error: {error:#}");
-    assert_ciphertext_unchanged::<BE>(&before, &truncated_output);
-
     let before = rejected.to_host_owned::<BE>();
     let error = module
         .ckks_paco_bootstrap_into::<_, _>(&mut rejected, &ct_in, &ctx, &keys, KAPPA, &mut scratch.borrow())

--- a/poulpy-core/src/default/external_product/glwe.rs
+++ b/poulpy-core/src/default/external_product/glwe.rs
@@ -61,19 +61,20 @@ fn glwe_external_product_dft_fill<BE, M>(
                 let (mut a_dft, mut scratch_1) = scratch
                     .borrow()
                     .take_vec_znx_dft_scratch(module, cols, (a.size() + di) / dsize);
-                res_dft.set_size(res_dft.max_size() - ((dsize - di) as isize - 2).max(0) as usize);
+                let res_compute_size = res_dft.max_size() - ((dsize - di) as isize - 2).max(0) as usize;
+                let mut res_view = res_dft.with_size_mut(res_compute_size);
 
                 for j in 0..cols {
                     module.vec_znx_dft_apply(dsize, dsize - 1 - di, &mut a_dft, j, &a.data, j);
                 }
 
                 if di == 0 {
-                    module.vmp_apply_dft_to_dft(res_dft, &a_dft.to_backend_ref(), &ggsw.data, 0, &mut scratch_1.borrow());
+                    module.vmp_apply_dft_to_dft(&mut res_view, &a_dft.to_backend_ref(), &ggsw.data, 0, &mut scratch_1.borrow());
                 } else {
                     let (mut res_dft_tmp, mut scratch_2) =
                         scratch_1
                             .borrow()
-                            .take_vec_znx_dft_scratch(module, res_dft.cols(), res_dft.size());
+                            .take_vec_znx_dft_scratch(module, res_view.cols(), res_view.size());
                     module.vmp_apply_dft_to_dft(
                         &mut res_dft_tmp,
                         &a_dft.to_backend_ref(),
@@ -82,13 +83,12 @@ fn glwe_external_product_dft_fill<BE, M>(
                         &mut scratch_2.borrow(),
                     );
                     for col in 0..cols {
-                        module.vec_znx_dft_add_assign(res_dft, col, &res_dft_tmp.to_backend_ref(), col);
+                        module.vec_znx_dft_add_assign(&mut res_view, col, &res_dft_tmp.to_backend_ref(), col);
                     }
                 }
             }
         }
     }
-    res_dft.set_size(res_dft.max_size());
 }
 
 impl<BE: Backend> GLWEExternalProductInternal<BE> for Module<BE>

--- a/poulpy-core/src/default/keyswitching/glwe.rs
+++ b/poulpy-core/src/default/keyswitching/glwe.rs
@@ -149,22 +149,27 @@ where
                         .borrow()
                         .take_vec_znx_dft_scratch(self, cols, ((a_size + di) / dsize).min(dnum));
 
-                res.set_size(res.max_size() - ((dsize - di) as isize - 2).max(0) as usize);
+                let res_compute_size = res.max_size() - ((dsize - di) as isize - 2).max(0) as usize;
+                let mut res_view = res.with_size_mut(res_compute_size);
 
                 for j in 0..cols {
                     self.vec_znx_dft_copy(dsize, dsize - di - 1, &mut ai_dft, j, a, j);
                 }
 
                 if di == 0 {
-                    self.vmp_apply_dft_to_dft(res, &ai_dft.to_backend_ref(), &key.data, 0, &mut scratch_1.borrow());
+                    self.vmp_apply_dft_to_dft(&mut res_view, &ai_dft.to_backend_ref(), &key.data, 0, &mut scratch_1.borrow());
                 } else {
                     // Accumulate directly into res, folding the per-column DFT add into the
                     // VMP save (drops the res_dft_tmp buffer + the separate add pass).
-                    self.vmp_apply_dft_to_dft_accumulate(res, &ai_dft.to_backend_ref(), &key.data, di, &mut scratch_1.borrow());
+                    self.vmp_apply_dft_to_dft_accumulate(
+                        &mut res_view,
+                        &ai_dft.to_backend_ref(),
+                        &key.data,
+                        di,
+                        &mut scratch_1.borrow(),
+                    );
                 }
             }
-
-            res.set_size(res.max_size());
         }
     }
 }

--- a/poulpy-hal/src/layouts/vec_znx.rs
+++ b/poulpy-hal/src/layouts/vec_znx.rs
@@ -65,7 +65,7 @@ impl VecZnxShape {
         self.max_size
     }
 
-    pub const fn with_size(self, size: usize) -> Self {
+    pub(crate) const fn with_size(self, size: usize) -> Self {
         assert!(size <= self.max_size);
         Self { size, ..self }
     }
@@ -210,26 +210,9 @@ impl<D: Data, W: ZnxWord> VecZnx<D, W> {
         self.shape
     }
 
-    pub fn with_size(mut self, size: usize) -> Self {
-        assert!(size <= self.max_size());
-        self.shape = self.shape.with_size(size);
-        self
-    }
-
     /// Returns the allocated limb capacity.
     pub fn max_size(&self) -> usize {
         self.shape.max_size()
-    }
-}
-
-impl<D: Data, W: ZnxWord> VecZnx<D, W> {
-    /// Sets the active limb count.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `size > max_size`.
-    pub fn set_size(&mut self, size: usize) {
-        self.shape = self.shape.with_size(size);
     }
 }
 

--- a/poulpy-hal/src/layouts/vec_znx_big.rs
+++ b/poulpy-hal/src/layouts/vec_znx_big.rs
@@ -114,16 +114,6 @@ impl<D: Data, W: BigWord, B: Backend<BigWord = W>> VecZnxBig<D, W, B> {
     pub fn max_size(&self) -> usize {
         self.shape.max_size()
     }
-
-    pub fn with_size(mut self, size: usize) -> Self {
-        assert!(size <= self.max_size());
-        self.shape = self.shape.with_size(size);
-        self
-    }
-
-    pub fn set_size(&mut self, size: usize) {
-        self.shape = self.shape.with_size(size);
-    }
 }
 
 impl<D: HostDataMut, W: BigWord, B: Backend<BigWord = W>> ZnxZero for VecZnxBig<D, W, B> {

--- a/poulpy-hal/src/layouts/vec_znx_dft.rs
+++ b/poulpy-hal/src/layouts/vec_znx_dft.rs
@@ -131,22 +131,24 @@ impl<D: Data, W: DftWord, B: Backend<DftWord = W>> VecZnxDft<D, W, B> {
     pub fn max_size(&self) -> usize {
         self.shape.max_size()
     }
-
-    pub fn with_size(mut self, size: usize) -> Self {
-        assert!(size <= self.max_size());
-        self.shape = self.shape.with_size(size);
-        self
-    }
 }
 
-impl<D: Data, W: DftWord, B: Backend<DftWord = W>> VecZnxDft<D, W, B> {
-    /// Sets the active limb count.
+impl<'b, B: Backend + 'b> VecZnxDftBackendMut<'b, B> {
+    /// Reborrows this buffer as a mutable view with a temporary compute size.
+    ///
+    /// The returned view has the same allocation capacity as `self`, but HAL
+    /// kernels see `size` as the active limb count. Dropping the view leaves
+    /// `self`'s metadata unchanged.
     ///
     /// # Panics
     ///
     /// Panics if `size > max_size`.
-    pub fn set_size(&mut self, size: usize) {
-        self.shape = self.shape.with_size(size)
+    pub fn with_size_mut(&mut self, size: usize) -> VecZnxDftBackendMut<'_, B> {
+        VecZnxDft {
+            data: B::view_mut_ref(&mut self.data),
+            shape: self.shape.with_size(size),
+            _phantom: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
Replace the mutating `set_size` and `with_size`  with view API, which removes obvious pitfalls of having to reset the size after ops.