### PR TITLE
Fix fixed-weight binary sampling in ScalarZnx

### DIFF
--- a/poulpy-cpu-ref/src/tests.rs
+++ b/poulpy-cpu-ref/src/tests.rs
@@ -212,6 +212,7 @@ backend_test_suite! {
     tests = {
         test_vec_znx_fill_uniform => poulpy_hal::test_suite::vec_znx::test_vec_znx_fill_uniform,
         test_vec_znx_seed_sampling_matches_source_wrappers => poulpy_hal::test_suite::vec_znx::test_vec_znx_seed_sampling_matches_source_wrappers,
+        test_scalar_znx_binary_hw_has_exact_weight => poulpy_hal::test_suite::vec_znx::test_scalar_znx_binary_hw_has_exact_weight,
         test_scalar_znx_secret_seed_sampling_matches_source_wrappers => poulpy_hal::test_suite::vec_znx::test_scalar_znx_secret_seed_sampling_matches_source_wrappers,
         test_vec_znx_fill_normal => poulpy_hal::test_suite::vec_znx::test_vec_znx_fill_normal,
         test_vec_znx_add_normal => poulpy_hal::test_suite::vec_znx::test_vec_znx_add_normal,

--- a/poulpy-hal/src/layouts/scalar_znx.rs
+++ b/poulpy-hal/src/layouts/scalar_znx.rs
@@ -179,9 +179,7 @@ impl<D: HostDataMut, W: ZnxWord> ScalarZnx<D, W> {
         // Zero-initialize before setting non-zero entries, since shuffle will
         // mix positions and we need indices hw..n to be zero.
         self.at_mut(col, 0).fill(W::zero());
-        self.at_mut(col, 0)[..hw]
-            .iter_mut()
-            .for_each(|x: &mut W| *x = W::from_i64((source.next_u32() & 1) as i64));
+        self.at_mut(col, 0)[..hw].fill(W::from_i64(1));
         self.at_mut(col, 0).shuffle(source);
     }
 

--- a/poulpy-hal/src/test_suite/vec_znx.rs
+++ b/poulpy-hal/src/test_suite/vec_znx.rs
@@ -2332,6 +2332,29 @@ pub fn test_vec_znx_seed_sampling_matches_source_wrappers<B: crate::test_suite::
     assert_eq!(download_vec_znx::<B>(&wrapper_normal), download_vec_znx::<B>(&backend_normal));
 }
 
+pub fn test_scalar_znx_binary_hw_has_exact_weight<B: crate::test_suite::TestBackend>(params: &TestParams, module: &Module<B>)
+where
+    Module<B>: ScalarZnxFillBinaryHwSourceBackend<B>,
+{
+    let n = params.size;
+    let hw = n / 8;
+    let host_init = ScalarZnx::alloc(n, 1);
+    let mut sampled = upload_scalar_znx::<B>(&host_init);
+
+    module.scalar_znx_fill_binary_hw_source_backend(
+        &mut <ScalarZnx<B::OwnedBuf, B::ZnxWord> as ScalarZnxToBackendMut<B>>::to_backend_mut(&mut sampled),
+        0,
+        hw,
+        &mut Source::new([0u8; 32]),
+    );
+
+    let sampled = download_scalar_znx::<B>(&sampled);
+    let coefficients = sampled.at(0, 0);
+
+    assert!(coefficients.iter().all(|&x| x == 0 || x == 1));
+    assert_eq!(coefficients.iter().filter(|&&x| x == 1).count(), hw);
+}
+
 pub fn test_scalar_znx_secret_seed_sampling_matches_source_wrappers<B: crate::test_suite::TestBackend>(
     _params: &TestParams,
     module: &Module<B>,


### PR DESCRIPTION
`ScalarZnx::fill_binary_hw` previously assigned random binary values to the first `hw` coefficients before shuffling. This produced approximately `hw / 2` ones on average instead of exactly `hw`.

Set the first `hw` coefficients to one before shuffling so that the resulting Hamming weight is exact.
Add a regression test that checks that all coefficients are binary and that the number of ones equals `hw`.
