### PR TITLE
Add release workflow & update cargo deps versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: nightly-2026-05-14
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    environment: release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+      - name: Check the tag matches the workspace version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          cargo metadata --format-version 1 --no-deps > "$RUNNER_TEMP/meta.json"
+          TAG="${GITHUB_REF#refs/tags/v}" python3 - <<'EOF'
+          import json, os, sys
+          tag = os.environ["TAG"]
+          pkgs = json.load(open(os.environ["RUNNER_TEMP"] + "/meta.json"))["packages"]
+          bad = sorted("%s %s" % (p["name"], p["version"]) for p in pkgs if p["version"] != tag)
+          if bad:
+              sys.exit("tag v%s does not match: %s" % (tag, ", ".join(bad)))
+          print("all %d crates at %s" % (len(pkgs), tag))
+          EOF
+
+      - name: Dry run
+        run: cargo publish --workspace --dry-run
+
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish
+        run: cargo publish --workspace
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-20
+
+- Update `dashu-float` to 0.6 and `astro-float-num` to 0.3.7, and refresh the `bytemuck`, `serde`, `serde_json` and `anyhow` pins. The dashu 0.6 context operations return a `Result`, which the internal binary128 helpers now unwrap; no public API changes.
+- Publish from CI through crates.io trusted publishing (`.github/workflows/release.yml`, triggered by a `v*` tag). The internal workspace dependencies carry a `version` requirement so `cargo publish` can package them.
+
 ## [0.8.0] - 2026-08-20
 
 Adds two native CKKS bootstrapping families, **PaCo** (Coron & Seuré, [ePrint 2025/886](https://eprint.iacr.org/2025/886)) and **SHIP** (Cheon, Hanrot, Kim & Stehlé, [ePrint 2025/784](https://eprint.iacr.org/2025/784)), moves CKKS encoding onto a backend-resident op family, and lands a production-readiness pass over `poulpy-ckks` (typed errors, constructor-validated plans, scratch-carved intermediates, binary128-exact tables, four-layer consolidation). Keys every polynomial layout by an explicit word type (`ZnxWord` / `BigWord` / `DftWord`) and the DFT/big containers by their backend, collapses the limb-width model to a claimed precision plus an allocation, and reparameterizes evaluation keys by an auxiliary guard `k_aux`. Trims gadget products to their live limbs on exact-DFT backends, opens the strided GGLWE product and tensoring to backend overrides, and lands a round of AVX2/AVX-512 NTT, VMP and convolution optimization. Opens the layouts, key containers and benchmarks to non-host device backends, and adds a reference-vs-backend byte-parity test suite.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "poulpy-bench"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "poulpy-bin-fhe",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "poulpy-bin-fhe"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "poulpy-ckks"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "astro-float-num",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "poulpy-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "poulpy-cpu-arm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "poulpy-cpu-avx"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "poulpy-cpu-avx512"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "poulpy-cpu-ref"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "poulpy-hal"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,15 +34,15 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "astro-float-num"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86887daca11d02e0b04f37a9cb81888aae881397fb48ff66494e356aea97554a"
+checksum = "bc7f6a0312e8f5845f84241b21bd2394d49940b6bc333c6a84f992e6dc9ebb85"
 dependencies = [
  "itertools 0.10.5",
  "lazy_static",
@@ -68,9 +68,9 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -249,34 +249,35 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dashu-base"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993b95dc1b248e3f5747dcb017a41d6e75853a2e5ee4504f7d537c5b8dffdae4"
+checksum = "fd9f3ef1b2d76f10fbc6a48d7b04e3dd8966242827ffcd987f3437c5e04ade21"
+dependencies = [
+ "num-modular",
+]
 
 [[package]]
 name = "dashu-float"
-version = "0.4.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779046eff25a959dd58c8d876dc9673ef2eaebd184fadf7313e27f73a10dd9bd"
+checksum = "542f7e260ebc9c95bec696d5a948238bbcf5f7c5eb621160531841d585958ef1"
 dependencies = [
  "dashu-base",
  "dashu-int",
  "num-modular",
  "num-order",
- "rustversion",
  "static_assertions",
 ]
 
 [[package]]
 name = "dashu-int"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c05a0d5cb0b39fcc87c46432fdac24b90dce239857c7f6b798be4ffc3c42c6"
+checksum = "87a89c01d9f8414897a573ab98d3bbb6b82be12017bb3c67920eb79830bcc620"
 dependencies = [
  "cfg-if",
  "dashu-base",
  "num-modular",
- "rustversion",
  "static_assertions",
 ]
 
@@ -481,9 +482,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-modular"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
+checksum = "bd8e500409e6cd603b03e477c26a6caecdc27ac58979a53e881c75eafc079f44"
 
 [[package]]
 name = "num-order"
@@ -750,7 +751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -864,12 +865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,9 +881,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -896,29 +891,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -944,6 +939,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1021,7 +1027,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1043,7 +1049,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1232,7 +1238,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1248,7 +1254,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1307,7 +1313,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ debug = true
 strip = false
 
 [workspace.dependencies]
-poulpy-hal = {path = "poulpy-hal"}
-poulpy-core = {path = "poulpy-core"}
-poulpy-cpu-avx = {path = "poulpy-cpu-avx"}
-poulpy-cpu-arm = {path = "poulpy-cpu-arm"}
-poulpy-cpu-ref = {path = "poulpy-cpu-ref"}
-poulpy-cpu-avx512 = {path = "poulpy-cpu-avx512"}
+poulpy-hal = {path = "poulpy-hal", version = "0.8.0"}
+poulpy-core = {path = "poulpy-core", version = "0.8.0"}
+poulpy-cpu-avx = {path = "poulpy-cpu-avx", version = "0.8.0"}
+poulpy-cpu-arm = {path = "poulpy-cpu-arm", version = "0.8.0"}
+poulpy-cpu-ref = {path = "poulpy-cpu-ref", version = "0.8.0"}
+poulpy-cpu-avx512 = {path = "poulpy-cpu-avx512", version = "0.8.0"}
 poulpy-bin-fhe = {path = "poulpy-bin-fhe"}
 poulpy-bench = {path = "poulpy-bench"}
-poulpy-ckks = {path = "poulpy-ckks"}
-dashu-float = "0.4.5"
-astro-float-num = { version = "0.3.6", default-features = false, features = ["std"] }
+poulpy-ckks = {path = "poulpy-ckks", version = "0.8.0"}
+dashu-float = "0.6.0"
+astro-float-num = { version = "0.3.7", default-features = false, features = ["std"] }
 # `poulpy-ckks` enables `unstable-float` only for its portable target graph.
 # Cargo then unifies that feature onto transitive users of this same libm; the
 # workspace's pinned nightly is therefore part of the fallback's contract.
@@ -36,8 +36,8 @@ criterion = "0.8.2"
 byteorder = "1.5.0"
 zstd = "0.13.3"
 once_cell = "1.21.4"
-bytemuck = { version = "1.25.0", features = ["min_const_generics"] }
+bytemuck = { version = "1.25.2", features = ["min_const_generics"] }
 paste = "1.0.15"
-serde = "1"
-serde_json = "1.0.150"
-anyhow = "1.0.103"
+serde = "1.0.229"
+serde_json = "1.0.151"
+anyhow = "1.0.104"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,15 @@ debug = true
 strip = false
 
 [workspace.dependencies]
-poulpy-hal = {path = "poulpy-hal", version = "0.8.0"}
-poulpy-core = {path = "poulpy-core", version = "0.8.0"}
-poulpy-cpu-avx = {path = "poulpy-cpu-avx", version = "0.8.0"}
-poulpy-cpu-arm = {path = "poulpy-cpu-arm", version = "0.8.0"}
-poulpy-cpu-ref = {path = "poulpy-cpu-ref", version = "0.8.0"}
-poulpy-cpu-avx512 = {path = "poulpy-cpu-avx512", version = "0.8.0"}
+poulpy-hal = {path = "poulpy-hal", version = "0.8.1"}
+poulpy-core = {path = "poulpy-core", version = "0.8.1"}
+poulpy-cpu-avx = {path = "poulpy-cpu-avx", version = "0.8.1"}
+poulpy-cpu-arm = {path = "poulpy-cpu-arm", version = "0.8.1"}
+poulpy-cpu-ref = {path = "poulpy-cpu-ref", version = "0.8.1"}
+poulpy-cpu-avx512 = {path = "poulpy-cpu-avx512", version = "0.8.1"}
 poulpy-bin-fhe = {path = "poulpy-bin-fhe"}
 poulpy-bench = {path = "poulpy-bench"}
-poulpy-ckks = {path = "poulpy-ckks", version = "0.8.0"}
+poulpy-ckks = {path = "poulpy-ckks", version = "0.8.1"}
 dashu-float = "0.6.0"
 astro-float-num = { version = "0.3.7", default-features = false, features = ["std"] }
 # `poulpy-ckks` enables `unstable-float` only for its portable target graph.

--- a/poulpy-bench/Cargo.toml
+++ b/poulpy-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poulpy-bench"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Consolidated benchmark suite for poulpy"

--- a/poulpy-bin-fhe/Cargo.toml
+++ b/poulpy-bin-fhe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poulpy-bin-fhe"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 readme = "README.md"

--- a/poulpy-ckks/Cargo.toml
+++ b/poulpy-ckks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poulpy-ckks"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 readme = "README.md"

--- a/poulpy-ckks/src/cosine.rs
+++ b/poulpy-ckks/src/cosine.rs
@@ -33,7 +33,7 @@ fn pi_big() -> FBig<HalfEven> {
 fn two_pi_big() -> FBig<HalfEven> {
     let pi = pi_big();
     let ctx = ctx();
-    ctx.mul(pi.repr(), FBig::<HalfEven>::from(2).repr()).value()
+    ctx.mul(pi.repr(), FBig::<HalfEven>::from(2).repr()).unwrap().value()
 }
 
 fn from_i64(x: i64) -> FBig<HalfEven> {
@@ -48,19 +48,19 @@ fn from_f64(x: f64) -> FBig<HalfEven> {
 }
 
 fn add(a: &FBig<HalfEven>, b: &FBig<HalfEven>) -> FBig<HalfEven> {
-    ctx().add(a.repr(), b.repr()).value()
+    ctx().add(a.repr(), b.repr()).unwrap().value()
 }
 
 fn sub(a: &FBig<HalfEven>, b: &FBig<HalfEven>) -> FBig<HalfEven> {
-    ctx().sub(a.repr(), b.repr()).value()
+    ctx().sub(a.repr(), b.repr()).unwrap().value()
 }
 
 fn mul(a: &FBig<HalfEven>, b: &FBig<HalfEven>) -> FBig<HalfEven> {
-    ctx().mul(a.repr(), b.repr()).value()
+    ctx().mul(a.repr(), b.repr()).unwrap().value()
 }
 
 fn div(a: &FBig<HalfEven>, b: &FBig<HalfEven>) -> FBig<HalfEven> {
-    ctx().div(a.repr(), b.repr()).value()
+    ctx().div(a.repr(), b.repr()).unwrap().value()
 }
 
 fn neg(a: &FBig<HalfEven>) -> FBig<HalfEven> {

--- a/poulpy-core/Cargo.toml
+++ b/poulpy-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poulpy-core"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 readme = "README.md"

--- a/poulpy-cpu-arm/Cargo.toml
+++ b/poulpy-cpu-arm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poulpy-cpu-arm"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 readme = "README.md"

--- a/poulpy-cpu-avx/Cargo.toml
+++ b/poulpy-cpu-avx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poulpy-cpu-avx"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 readme = "README.md"

--- a/poulpy-cpu-avx512/Cargo.toml
+++ b/poulpy-cpu-avx512/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poulpy-cpu-avx512"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 readme = "README.md"

--- a/poulpy-cpu-ref/Cargo.toml
+++ b/poulpy-cpu-ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poulpy-cpu-ref"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 readme = "README.md"

--- a/poulpy-hal/Cargo.toml
+++ b/poulpy-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poulpy-hal"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "Apache-2.0"
 readme = "README.md"

--- a/poulpy-hal/src/layouts/encoding.rs
+++ b/poulpy-hal/src/layouts/encoding.rs
@@ -376,11 +376,14 @@ impl<D: HostDataRef> VecZnx<D, i64> {
         (0..size).for_each(|i| {
             if i == 0 {
                 izip!(a.at(col, size - i - 1).iter(), data.iter_mut()).for_each(|(x, y)| {
-                    *y = ctx.div(FBig::<HalfEven>::from(*x).repr(), scale.repr()).value();
+                    *y = ctx.div(FBig::<HalfEven>::from(*x).repr(), scale.repr()).unwrap().value();
                 });
             } else {
                 izip!(a.at(col, size - i - 1).iter(), data.iter_mut()).for_each(|(x, y)| {
-                    *y = ctx.div((y.clone() + FBig::<HalfEven>::from(*x)).repr(), scale.repr()).value();
+                    *y = ctx
+                        .div((y.clone() + FBig::<HalfEven>::from(*x)).repr(), scale.repr())
+                        .unwrap()
+                        .value();
                 });
             }
         });


### PR DESCRIPTION
## Add a trusted-publishing release workflow

Publishes the workspace to crates.io from CI, with no stored API token.

`.github/workflows/release.yml` runs on a `v*` tag push or manual dispatch:

1. Checks every crate version matches the tag, and fails listing any that disagree.
2. Runs `cargo publish --workspace --dry-run`.
3. Mints a short-lived crates.io token from GitHub's OIDC identity via
   `rust-lang/crates-io-auth-action`, revoked when the job ends.
4. Runs `cargo publish --workspace`, which publishes the eight crates in
   dependency order and skips `poulpy-bench` (`publish = false`).

Gated on an `release` environment so a reviewer can approve before an
irreversible publish. Toolchain install matches `ci.yml`.

`Cargo.toml` gains `version = "0.8.0"` on the seven internal dependencies used as
normal dependencies. Without it `cargo publish` refuses to package
(`all dependencies must have a version requirement specified`), which is why
previous releases needed a local manifest edit. `poulpy-bin-fhe` and
`poulpy-bench` stay path-only on purpose: both are dev-dependencies only, and
versioning `poulpy-bin-fhe` would create a publish cycle with `poulpy-cpu-ref`.
