### PR TITLE
Jp/fix modup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Add the missing `GGLWEPreparedToBackendRef` impl for `GLWETensorKeyPrepared`, the twin of the `Mut` one. The newtype field and every `GGLWEPrepared` field are `pub(crate)`, so no downstream crate could supply it. The relinearization path (`GLWETensoringImpl::glwe_tensor_relinearize` and the `poulpy-ckks` `mul` / `polynomial_evaluation` / `composite` chains that reach it) carries the bound alongside `GLWETensorKeyPreparedToBackendRef`, so a backend override can read the key's `VmpPMat` without naming the newtype field.
 
+### `poulpy-ckks`
+
+- ModUp lifts `Δ·m` to `k - log_msg_ratio`, then to `f_mod_log_delta` fused into the widening shift, both before the sparse-to-dense switch. Recovers `f_mod_log_delta - k` bits (19.7 → 26.9 at `LogN=16`, `Δ=2^40`, ratio `2^8`). C2S-first only.
+- **Breaking:** `ckks_mod_up_into` takes `&EvalModPlan` and returns a labelled ciphertext; new `ckks_bootstrap_mod_up` does the whole raise step; `CKKSEncapsulatedModUpImpl::ckks_encapsulated_mod_up` takes `scale_up`.
+
 ## [0.8.1] - 2026-08-20
 
 - Update `dashu-float` to 0.6 and `astro-float-num` to 0.3.7, and refresh the `bytemuck`, `serde`, `serde_json` and `anyhow` pins. The dashu 0.6 context operations return a `Result`, which the internal binary128 helpers now unwrap; no public API changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### `poulpy-core`
+
+- Add the missing `GGLWEPreparedToBackendRef` impl for `GLWETensorKeyPrepared`, the twin of the `Mut` one. The newtype field and every `GGLWEPrepared` field are `pub(crate)`, so no downstream crate could supply it. The relinearization path (`GLWETensoringImpl::glwe_tensor_relinearize` and the `poulpy-ckks` `mul` / `polynomial_evaluation` / `composite` chains that reach it) carries the bound alongside `GLWETensorKeyPreparedToBackendRef`, so a backend override can read the key's `VmpPMat` without naming the newtype field.
+
 ## [0.8.1] - 2026-08-20
 
 - Update `dashu-float` to 0.6 and `astro-float-num` to 0.3.7, and refresh the `bytemuck`, `serde`, `serde_json` and `anyhow` pins. The dashu 0.6 context operations return a `Result`, which the internal binary128 helpers now unwrap; no public API changes.

--- a/poulpy-ckks/src/api/bootstrapping.rs
+++ b/poulpy-ckks/src/api/bootstrapping.rs
@@ -5,6 +5,7 @@ use poulpy_hal::layouts::{Backend, ScratchArena};
 use crate::{
     CKKSCtBounds, SetCKKSInfos,
     api::{CKKSDFTOps, CKKSEvalModOps},
+    layouts::EvalModPlan,
     layouts::{
         BootstrappingContext, BootstrappingKeys, BootstrappingKeysLayout, CKKSCiphertextOwned, CKKSPlaintextOwned, EncodedLut,
     },
@@ -72,10 +73,46 @@ pub trait CKKSBootstrappingOps<BE: Backend>: CKKSDFTOps<BE> + CKKSEvalModOps<BE>
     /// `dst` must carry the target (raised) modulus: `dst.k() ≥
     /// src.k()`. See the trait docs for the exact semantics and
     /// metadata effect.
-    fn ckks_mod_up_into<Dst, Src>(&self, dst: &mut Dst, src: &Src, scratch: &mut ScratchArena<'_, BE>) -> Result<()>
+    ///
+    /// `eval_mod` supplies the lift: the raise stops short of the natural
+    /// magnitude so the message lands at the plan's scale rather than the input
+    /// modulus'. `src` is expected to already carry the plan's message ratio.
+    /// `dst` comes back fully labelled, at the plan's scale: no metadata stamping
+    /// is left to the caller.
+    ///
+    /// This is the bare stage. For the whole raise step, including the
+    /// encapsulation switches, use [`Self::ckks_bootstrap_mod_up`].
+    fn ckks_mod_up_into<Dst, Src>(
+        &self,
+        dst: &mut Dst,
+        src: &Src,
+        eval_mod: &EvalModPlan,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) -> Result<()>
     where
         Dst: GLWEToBackendMut<BE> + CKKSCtBounds + SetCKKSInfos,
         Src: GLWEToBackendRef<BE> + CKKSCtBounds;
+
+    /// Whole raise step of the bootstrap, as one call: lift `Δ·m` to the plan's
+    /// message ratio, switch to the sparse secret when `keys` carry the
+    /// encapsulation switches, ModUp into `dst` (with the second lift to the
+    /// plan's scale fused into its shift), switch back, and relabel by the
+    /// message ratio so `I(X)·q` is the integer part and the message the residue.
+    ///
+    /// `dst` must be allocated at the bootstrap modulus. Scratch is bounded by
+    /// [`Self::ckks_bootstrap_tmp_bytes`].
+    fn ckks_bootstrap_mod_up<Dst, Src, K>(
+        &self,
+        dst: &mut Dst,
+        src: &Src,
+        eval_mod: &EvalModPlan,
+        keys: &K,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) -> Result<()>
+    where
+        Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
+        Src: GLWEToBackendRef<BE> + CKKSCtBounds,
+        K: BootstrappingKeys<BE>;
 
     /// One-shot CKKS bootstrap, driven by the compiled context.
     ///

--- a/poulpy-ckks/src/api/composite.rs
+++ b/poulpy-ckks/src/api/composite.rs
@@ -2,7 +2,7 @@ use crate::CKKSResult as Result;
 use poulpy_core::layouts::IntPolyInfos;
 use poulpy_core::layouts::{
     GGLWEInfos, GLWE, GLWEInfos, GLWETensorKeyPrepared, GLWEToBackendMut, GLWEToBackendRef, LWEInfos,
-    prepared::GLWETensorKeyPreparedToBackendRef,
+    prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPreparedToBackendRef},
 };
 use poulpy_hal::layouts::{Backend, Data, ScratchArena};
 
@@ -100,7 +100,7 @@ pub trait CKKSMulAddOps<BE: Backend> {
         Dst: GLWEToBackendMut<BE> + CKKSCtBounds + SetCKKSInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds,
         B: GLWEToBackendRef<BE> + CKKSCtBounds,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     /// Computes `dst += a * pt` where `pt` is a full plaintext polynomial.
     ///
@@ -345,7 +345,7 @@ pub trait CKKSMulSubOps<BE: Backend> {
         Dst: GLWEToBackendMut<BE> + CKKSCtBounds + SetCKKSInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds,
         B: GLWEToBackendRef<BE> + CKKSCtBounds,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     /// Computes `dst -= a * pt` where `pt` is a full plaintext polynomial.
     ///
@@ -427,7 +427,7 @@ pub trait CKKSDotProductOps<BE: Backend> {
         CKKSCiphertext<Dst, BE::ZnxWord>: GLWEToBackendMut<BE>,
         CKKSCiphertext<D, BE::ZnxWord>: GLWEToBackendRef<BE> + LWEInfos + GLWEInfos,
         CKKSCiphertext<E, BE::ZnxWord>: GLWEToBackendRef<BE> + LWEInfos + GLWEInfos,
-        GLWETensorKeyPrepared<T, BE>: GLWETensorKeyPreparedToBackendRef<BE>;
+        GLWETensorKeyPrepared<T, BE>: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     /// Computes `dst = Σ a[i] * b[i]` over ciphertext–plaintext-polynomial pairs.
     ///

--- a/poulpy-ckks/src/api/mul.rs
+++ b/poulpy-ckks/src/api/mul.rs
@@ -1,7 +1,10 @@
 use crate::CKKSResult as Result;
 use poulpy_core::layouts::GLWEToBackendMut;
 use poulpy_core::layouts::IntPolyInfos;
-use poulpy_core::layouts::{GGLWEInfos, GLWEToBackendRef, prepared::GLWETensorKeyPreparedToBackendRef};
+use poulpy_core::layouts::{
+    GGLWEInfos, GLWEToBackendRef,
+    prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPreparedToBackendRef},
+};
 use poulpy_hal::layouts::{Backend, ScratchArena};
 
 use crate::{CKKSCtBounds, CKKSInfos, SetCKKSInfos, layouts::CKKSPreparedRight};
@@ -133,14 +136,14 @@ pub trait CKKSMulOps<BE: Backend> {
         Dst: GLWEToBackendMut<BE> + CKKSCtBounds + SetCKKSInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds,
         B: GLWEToBackendRef<BE> + CKKSCtBounds,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     /// Computes `dst *= a` in-place using tensor-product keyswitching via `tsk`.
     fn ckks_mul_assign<Dst, A, T>(&self, dst: &mut Dst, a: &A, tsk: &T, scratch: &mut ScratchArena<'_, BE>) -> Result<()>
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     /// Prepares `a` as a reusable right operand for [`Self::ckks_mul_prepared_assign`].
     ///
@@ -168,7 +171,7 @@ pub trait CKKSMulOps<BE: Backend> {
     ) -> Result<()>
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     /// Computes `dst = a * a` (squaring) using tensor-product keyswitching.
     ///
@@ -177,13 +180,13 @@ pub trait CKKSMulOps<BE: Backend> {
     where
         Dst: GLWEToBackendMut<BE> + CKKSCtBounds + SetCKKSInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     /// Computes `dst = dst * dst` (squaring in-place) using tensor-product keyswitching.
     fn ckks_square_assign<Dst, T>(&self, dst: &mut Dst, tsk: &T, scratch: &mut ScratchArena<'_, BE>) -> Result<()>
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     /// Computes `dst = a * pt` where `pt` is a full plaintext polynomial.
     ///

--- a/poulpy-ckks/src/api/polynomial_evaluation.rs
+++ b/poulpy-ckks/src/api/polynomial_evaluation.rs
@@ -4,7 +4,7 @@ use poulpy_hal::layouts::{Backend, ScratchArena};
 
 use poulpy_core::layouts::{
     BSGSMeta, GGLWEInfos, GLWEInfos, GLWEToBackendMut, GLWEToBackendRef, SetBSGSMeta,
-    prepared::{GLWETensorKeyPrepared, GLWETensorKeyPreparedToBackendRef},
+    prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPrepared, GLWETensorKeyPreparedToBackendRef},
 };
 
 use crate::{CKKSCtBounds, SetCKKSInfos, layouts::CKKSCiphertextOwned, polynomial::ComplexBSGSPolynomial};
@@ -26,7 +26,7 @@ pub trait CKKSPolynomialEvaluationOps<BE: Backend> {
         B::Coeffs: CKKSCtBounds,
         A: GLWEToBackendRef<BE> + CKKSCtBounds + BSGSMeta,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     /// Evaluates a complex-coefficient polynomial `Σ_k (a_k + i·b_k)·z^k`,
     /// where `poly.re`/`poly.im` are the matched real/imag BSGS decompositions
@@ -44,7 +44,7 @@ pub trait CKKSPolynomialEvaluationOps<BE: Backend> {
         C: GLWEToBackendRef<BE> + GLWEInfos + BSGSMeta + CKKSCtBounds + IntPolyInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds + BSGSMeta,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     /// Builds the power basis internally then evaluates a real-coefficient
     /// polynomial.

--- a/poulpy-ckks/src/default/bootstrapping.rs
+++ b/poulpy-ckks/src/default/bootstrapping.rs
@@ -276,18 +276,19 @@ impl<BE: Backend + CKKSEncapsulatedModUpImpl<BE>> BootstrappingDefault<'_, BE> {
         Src: GLWEToBackendRef<BE> + CKKSCtBounds,
         CKKSCiphertextOwned<BE>: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
     {
+        // The pipeline carves rank-1 intermediates, so reject higher-rank inputs
+        // rather than silently copying into a rank-1 scratch ciphertext.
+        ckks_ensure!(
+            src.rank().as_usize() == 1 && dst.rank().as_usize() == 1,
+            "ckks_bootstrap_mod_up supports rank-1 ciphertexts only, got rank {} -> {}",
+            src.rank().as_usize(),
+            dst.rank().as_usize()
+        );
+
         // The input-width copy is scoped so its scratch is released right after
         // ModUp widens it into `dst`.
         scratch.scope(|scratch_inner| {
-            let (mut ct0, mut scratch_inner) = scratch_inner.take_ckks_ciphertext_scratch(
-                &GLWELayout {
-                    n: src.n(),
-                    base2k: src.base2k(),
-                    k: src.k(),
-                    rank: Rank(1),
-                },
-                src.meta(),
-            );
+            let (mut ct0, mut scratch_inner) = scratch_inner.take_ckks_ciphertext_scratch(src, src.meta());
             self.ckks_copy(&mut ct0, src, &mut scratch_inner)?;
             self.ckks_bootstrap_mod_up_from_mut(dst, &mut ct0, Some(eval_mod), keys, &mut scratch_inner)
         })?;

--- a/poulpy-ckks/src/default/bootstrapping.rs
+++ b/poulpy-ckks/src/default/bootstrapping.rs
@@ -1,4 +1,4 @@
-use crate::{CKKSResult as Result, ckks_ensure};
+use crate::{CKKSResult as Result, ckks_ensure, layouts::eval_mod::EvalModPlan};
 use poulpy_core::{
     GLWECopy, GLWEKeyswitch, GLWEShift,
     layouts::{
@@ -140,10 +140,11 @@ impl<BE: Backend + CKKSEncapsulatedModUpImpl<BE>> BootstrappingDefault<'_, BE> {
             ))
             .max(self.ckks_eval_mod_tmp_bytes(&boot_layout, &boot_layout, ctx.eval_mod(), &keys_layout.tensor_key));
 
+        if ctx.pipeline() == BootstrappingPipeline::C2SFirst {
+            carved += in_ct_bytes;
+        }
+
         if let Some(encaps) = &keys_layout.encapsulation {
-            if ctx.pipeline() == BootstrappingPipeline::C2SFirst {
-                carved += in_ct_bytes;
-            }
             nested = nested.max(BE::ckks_encapsulated_mod_up_tmp_bytes(
                 self.0,
                 &boot_layout,
@@ -205,10 +206,13 @@ impl<BE: Backend + CKKSEncapsulatedModUpImpl<BE>> BootstrappingDefault<'_, BE> {
         base.max(carved + nested)
     }
 
+    /// `scale_up` lifts the message that many bits above its natural magnitude,
+    /// fused into the widening shift rather than costing a second pass.
     pub(crate) fn ckks_mod_up_into_default<Dst, Src>(
         &self,
         dst: &mut Dst,
         src: &Src,
+        scale_up: usize,
         scratch: &mut ScratchArena<'_, BE>,
     ) -> Result<()>
     where
@@ -224,8 +228,8 @@ impl<BE: Backend + CKKSEncapsulatedModUpImpl<BE>> BootstrappingDefault<'_, BE> {
         let k_small: usize = src.k().as_usize();
 
         ckks_ensure!(
-            k_large >= k_small,
-            "ckks_mod_up: dst.k ({k_large}) < src.k ({k_small}); ModUp must widen, not shrink, the modulus"
+            k_large >= k_small + scale_up,
+            "ckks_mod_up: dst.k ({k_large}) < src.k ({k_small}) + scale_up ({scale_up}); ModUp must widen, not shrink, the modulus"
         );
 
         // MSB-align `src` into the wider `dst`: the value occupies the top
@@ -235,15 +239,17 @@ impl<BE: Backend + CKKSEncapsulatedModUpImpl<BE>> BootstrappingDefault<'_, BE> {
         // Shift the digits down to their natural integer magnitude. This is the
         // modulus raise: the raised-from modulus `q = 2^k_small` becomes an
         // explicit, un-reduced multiple `I(X)·q` living in the `[0, 2^k_large)`
-        // window, which EvalMod subsequently removes. (A zero shift — when the
-        // input already fills the storage — is a no-op.)
-        self.glwe_rsh(k_large - k_small, dst, scratch);
+        // window, which EvalMod subsequently removes. (A zero shift, when the
+        // input already fills the storage, is a no-op.) Stopping `scale_up` bits
+        // short of the natural magnitude is the fused lift: the value lands
+        // multiplied by `2^scale_up`, absorbed by the matching `log_delta`.
+        self.glwe_rsh(k_large - k_small - scale_up, dst, scratch);
 
-        // `log_delta` is unchanged (the integer `Δ·m` keeps its scale); the
-        // remaining headroom now spans the full raised modulus, so the torus
+        // `log_delta` picks up the fused lift, so the encoded value is unchanged;
+        // the remaining headroom now spans the full raised modulus, so the torus
         // width `k` becomes `k_large` and `log_budget = k_large - log_delta`.
         dst.set_meta(CKKSMeta {
-            log_delta: src.log_delta(),
+            log_delta: src.log_delta() + scale_up,
             log_sparsity: src.log_sparsity(),
             slots: src.slots(),
         });
@@ -252,24 +258,87 @@ impl<BE: Backend + CKKSEncapsulatedModUpImpl<BE>> BootstrappingDefault<'_, BE> {
         Ok(())
     }
 
-    fn ckks_bootstrap_mod_up_from_mut<Dst, Src, K>(
+    /// Whole raise step: lift to the plan's message ratio, (encapsulate) ModUp
+    /// with the second lift fused into its shift, then relabel by the message
+    /// ratio so `I(X)·q` is the integer part and the message the residue.
+    pub(crate) fn ckks_bootstrap_mod_up_default<Dst, Src, K>(
         &self,
         dst: &mut Dst,
-        src: &mut Src,
+        src: &Src,
+        eval_mod: &EvalModPlan,
         keys: &K,
         scratch: &mut ScratchArena<'_, BE>,
     ) -> Result<()>
     where
-        Module<BE>: GLWECopy<BE> + GLWEShift<BE> + GLWEKeyswitch<BE>,
+        Module<BE>: GLWECopy<BE> + GLWEShift<BE> + GLWEKeyswitch<BE> + CKKSPow2Ops<BE> + CKKSCopyOps<BE>,
+        K: BootstrappingKeys<BE>,
+        Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
+        Src: GLWEToBackendRef<BE> + CKKSCtBounds,
+        CKKSCiphertextOwned<BE>: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
+    {
+        // The input-width copy is scoped so its scratch is released right after
+        // ModUp widens it into `dst`.
+        scratch.scope(|scratch_inner| {
+            let (mut ct0, mut scratch_inner) = scratch_inner.take_ckks_ciphertext_scratch(
+                &GLWELayout {
+                    n: src.n(),
+                    base2k: src.base2k(),
+                    k: src.k(),
+                    rank: Rank(1),
+                },
+                src.meta(),
+            );
+            self.ckks_copy(&mut ct0, src, &mut scratch_inner)?;
+            self.ckks_bootstrap_mod_up_from_mut(dst, &mut ct0, Some(eval_mod), keys, &mut scratch_inner)
+        })?;
+
+        dst.set_meta(CKKSMeta {
+            log_sparsity: src.log_sparsity(),
+            log_delta: dst.log_delta() + eval_mod.log_msg_ratio,
+            slots: src.slots(),
+        });
+        Ok(())
+    }
+
+    fn ckks_bootstrap_mod_up_from_mut<Dst, Src, K>(
+        &self,
+        dst: &mut Dst,
+        src: &mut Src,
+        lift: Option<&EvalModPlan>,
+        keys: &K,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) -> Result<()>
+    where
+        Module<BE>: GLWECopy<BE> + GLWEShift<BE> + GLWEKeyswitch<BE> + CKKSPow2Ops<BE>,
         K: BootstrappingKeys<BE>,
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
         Src: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
     {
+        // Both lifts come from the plan; `None` skips them (for pipelines whose
+        // input does not meet the plan's message-ratio contract). The first
+        // normalizes the input to that ratio, the second takes the raised
+        // ciphertext up to EvalMod's own scale and is fused into ModUp's shift.
+        let mut scale_up = 0;
+        if let Some(plan) = lift {
+            let k: usize = src.k().as_usize();
+            let log_delta: usize = src.log_delta();
+            let scale_up_in = plan.input_scale_up(k, log_delta)?;
+            if scale_up_in != 0 {
+                self.ckks_mul_pow2_assign(src, scale_up_in, scratch)?;
+                // Not `set_log_delta`: it preserves `log_budget` and grows `k`, which
+                // cancels the shift. The lift spends budget at a fixed modulus.
+                let mut meta = src.meta();
+                meta.log_delta = log_delta + scale_up_in;
+                src.set_meta(meta);
+            }
+            scale_up = plan.raised_scale_up(src.log_delta())?;
+        }
+
         match keys.encapsulation_keys() {
             Some((dense_to_sparse, sparse_to_dense)) => {
-                BE::ckks_encapsulated_mod_up(self.0, dst, src, dense_to_sparse, sparse_to_dense, scratch)?;
+                BE::ckks_encapsulated_mod_up(self.0, dst, src, scale_up, dense_to_sparse, sparse_to_dense, scratch)?;
             }
-            None => self.ckks_mod_up_into_default(dst, src, scratch)?,
+            None => self.ckks_mod_up_into_default(dst, src, scale_up, scratch)?,
         }
         Ok(())
     }
@@ -479,7 +548,7 @@ impl<BE: Backend + CKKSEncapsulatedModUpImpl<BE>> BootstrappingDefault<'_, BE> {
             )?;
 
             let log_modulus_in = ct_coeffs.k().as_usize();
-            self.ckks_bootstrap_mod_up_from_mut(ct_raised, &mut ct_coeffs, keys, &mut scratch_inner)?;
+            self.ckks_bootstrap_mod_up_from_mut(ct_raised, &mut ct_coeffs, None, keys, &mut scratch_inner)?;
             ct_raised.set_meta(CKKSMeta {
                 log_sparsity: ct_in.log_sparsity(),
                 log_delta: log_modulus_in,
@@ -548,7 +617,6 @@ impl<BE: Backend + CKKSEncapsulatedModUpImpl<BE>> BootstrappingDefault<'_, BE> {
 
         let base2k = ct_in.base2k();
         let k_boot = ct_out.k();
-        let log_modulus_in = ct_in.k();
         let boot_layout = GLWELayout {
             n: ct_out.n(),
             base2k,
@@ -561,36 +629,7 @@ impl<BE: Backend + CKKSEncapsulatedModUpImpl<BE>> BootstrappingDefault<'_, BE> {
             // integer wrap-around `I·q` exposed by ModUp is bounded by the *sparse* secret's
             // Hamming weight (https://eprint.iacr.org/2022/024).
             let (mut ct, mut scratch_local) = scratch_local.take_ckks_ciphertext_scratch(&boot_layout, ct_in.meta());
-            match encapsulation_keys {
-                Some(_) => {
-                    // The input-width copy is scoped so its scratch is released
-                    // right after ModUp widens it into `ct`.
-                    scratch_local.scope(|scratch_inner| {
-                        let (mut ct0, mut scratch_inner) = scratch_inner.take_ckks_ciphertext_scratch(
-                            &GLWELayout {
-                                n: ct_in.n(),
-                                base2k,
-                                k: log_modulus_in,
-                                rank: Rank(1),
-                            },
-                            ct_in.meta(),
-                        );
-                        self.ckks_copy(&mut ct0, ct_in, &mut scratch_inner)?;
-                        self.ckks_bootstrap_mod_up_from_mut(&mut ct, &mut ct0, keys, &mut scratch_inner)
-                    })?;
-                }
-                None => {
-                    self.ckks_mod_up_into_default(&mut ct, ct_in, &mut scratch_local)?;
-                }
-            }
-
-            // Relabel at the input-modulus scale (free /message-ratio): the integer
-            // wrap-around becomes the integer part, the message the residue.
-            ct.set_meta(CKKSMeta {
-                log_sparsity: ct_in.log_sparsity(),
-                log_delta: log_modulus_in.as_usize(),
-                slots: ct_in.slots(),
-            });
+            self.ckks_bootstrap_mod_up_default(&mut ct, ct_in, &ctx.eval_mod().plan, keys, &mut scratch_local)?;
 
             // CoeffsToSlots (split): coefficients → (real, imag) slots. In the standard
             // pipeline this feeds EvalMod directly; in EvalRound+ it is the low-precision
@@ -874,20 +913,23 @@ pub fn ckks_encapsulated_mod_up_default<BE, Dst, Src, D2S, S2D>(
     module: &Module<BE>,
     dst: &mut Dst,
     src: &mut Src,
+    scale_up: usize,
     dense_to_sparse: &D2S,
     sparse_to_dense: &S2D,
     scratch: &mut ScratchArena<'_, BE>,
 ) -> Result<()>
 where
     BE: Backend + CKKSEncapsulatedModUpImpl<BE>,
-    Module<BE>: GLWECopy<BE> + GLWEShift<BE> + GLWEKeyswitch<BE>,
+    Module<BE>: GLWECopy<BE> + GLWEShift<BE> + GLWEKeyswitch<BE> + CKKSPow2Ops<BE>,
     Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
     Src: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
     D2S: poulpy_core::layouts::prepared::GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     S2D: GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
 {
     module.glwe_keyswitch_assign(src, dense_to_sparse, scratch);
-    BootstrappingDefault::new(module).ckks_mod_up_into_default(dst, src, scratch)?;
+    // The lift is fused into ModUp, so the message is already at its final scale
+    // when sparse-to-dense adds its noise.
+    BootstrappingDefault::new(module).ckks_mod_up_into_default(dst, src, scale_up, scratch)?;
     module.glwe_keyswitch_assign(dst, sparse_to_dense, scratch);
     Ok(())
 }

--- a/poulpy-ckks/src/default/mul.rs
+++ b/poulpy-ckks/src/default/mul.rs
@@ -5,7 +5,8 @@ use poulpy_core::{
     glwe_prepare_right, glwe_tensor_apply_prepared_right,
     layouts::{
         GGLWEInfos, GLWEInfos, GLWELayout, GLWEPlaintextLayout, GLWETensorViewMut, GLWEToBackendMut, GLWEToBackendRef, LWEInfos,
-        ModuleCoreAlloc, TorusPrecision, prepared::GLWETensorKeyPreparedToBackendRef,
+        ModuleCoreAlloc, TorusPrecision,
+        prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPreparedToBackendRef},
     },
 };
 use poulpy_hal::{
@@ -64,7 +65,7 @@ pub trait CKKSMulDefault<BE: Backend> {
         Dst: GLWEToBackendMut<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
         A: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
         B: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         let (res_log_budget, res_log_delta, cnv_offset) = get_mul_ct_params(dst, a, b)?;
 
@@ -91,7 +92,7 @@ pub trait CKKSMulDefault<BE: Backend> {
         Self: GLWETensoring<BE> + GLWECopy<BE> + ModuleCoreAlloc<OwnedBuf = BE::OwnedBuf, ZnxWord = BE::ZnxWord>,
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
         A: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         let (res_log_budget, res_log_delta, cnv_offset) = get_mul_ct_params(dst, dst, a)?;
 
@@ -152,7 +153,7 @@ pub trait CKKSMulDefault<BE: Backend> {
     where
         Self: GLWETensoring<BE> + GiantStepTensorBounds<BE>,
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         // Prepared operands are long-lived cached objects: reject one built
         // under a different ring degree, radix, or rank before touching `dst`.
@@ -228,7 +229,7 @@ pub trait CKKSMulDefault<BE: Backend> {
         Self: GLWETensoring<BE> + GLWECopy<BE> + ModuleCoreAlloc<OwnedBuf = BE::OwnedBuf, ZnxWord = BE::ZnxWord>,
         Dst: GLWEToBackendMut<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
         A: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         let (res_log_budget, res_log_delta, cnv_offset) = get_mul_ct_params(dst, a, a)?;
 
@@ -253,7 +254,7 @@ pub trait CKKSMulDefault<BE: Backend> {
     where
         Self: GLWETensoring<BE> + GLWECopy<BE> + ModuleCoreAlloc<OwnedBuf = BE::OwnedBuf, ZnxWord = BE::ZnxWord>,
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         let (res_log_budget, res_log_delta, cnv_offset) = get_mul_ct_params(dst, dst, dst)?;
 
@@ -453,7 +454,7 @@ where
     BE: Backend,
     M: GLWETensoring<BE> + ?Sized,
     Dst: GLWEToBackendMut<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
-    T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+    T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
 {
     let do_stamp = |dst: &mut Dst| {
         dst.set_log_budget(stamp.log_budget);

--- a/poulpy-ckks/src/default/paco/ops.rs
+++ b/poulpy-ckks/src/default/paco/ops.rs
@@ -36,7 +36,8 @@ use crate::{CKKSResult as Result, ckks_ensure};
 use poulpy_core::{
     GLWEAutomorphism,
     layouts::{
-        GGLWEInfos, GLWEAutomorphismKeyHelper, GLWEToBackendMut, GLWEToBackendRef, prepared::GLWETensorKeyPreparedToBackendRef,
+        GGLWEInfos, GLWEAutomorphismKeyHelper, GLWEToBackendMut, GLWEToBackendRef,
+        prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPreparedToBackendRef},
     },
 };
 use poulpy_hal::{
@@ -119,7 +120,7 @@ pub trait PaCoSlotOps<BE: Backend> {
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
         K: CKKSAtkBounds<BE>,
         H: GLWEAutomorphismKeyHelper<K, BE>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 }
 
 impl<BE: Backend> PaCoSlotOps<BE> for Module<BE>
@@ -166,7 +167,7 @@ where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
         K: CKKSAtkBounds<BE>,
         H: GLWEAutomorphismKeyHelper<K, BE>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         let rotations = checked_fold_rotations(self, a, b)?;
         let mut tmp = self.ckks_ciphertext_alloc_from_infos(ct);

--- a/poulpy-ckks/src/default/polynomial_evaluation.rs
+++ b/poulpy-ckks/src/default/polynomial_evaluation.rs
@@ -2,7 +2,7 @@ use crate::{CKKSResult as Result, ckks_ensure};
 use poulpy_core::layouts::IntPolyInfos;
 use poulpy_core::layouts::{
     BSGSMeta, GGLWEInfos, GLWEInfos, GLWEToBackendMut, GLWEToBackendRef, LWEInfos, SetBSGSMeta,
-    prepared::GLWETensorKeyPreparedToBackendRef,
+    prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPreparedToBackendRef},
 };
 use poulpy_core::{BSGSOps, GLWEPolynomialEvaluation, GLWEZero};
 use poulpy_hal::layouts::{Backend, Module, ScratchArena, ZnxWord};
@@ -130,7 +130,7 @@ where
         scratch: &mut ScratchArena<'_, BE>,
     ) -> anyhow::Result<()>
     where
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         module
             .ckks_mul_prepared_assign(dst, prepared, tsk, scratch)
@@ -163,7 +163,7 @@ pub trait PolynomialEvaluationDefault<BE: Backend> {
         B::Coeffs: CKKSCtBounds,
         A: GLWEToBackendRef<BE> + GLWEInfos + BSGSMeta + CKKSCtBounds,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     fn ckks_eval_poly_complex_const_coeffs_from_power_basis_default<R, C, A, G, T>(
         &self,
@@ -186,7 +186,7 @@ pub trait PolynomialEvaluationDefault<BE: Backend> {
         C: GLWEToBackendRef<BE> + GLWEInfos + BSGSMeta + CKKSCtBounds + IntPolyInfos,
         A: GLWEToBackendRef<BE> + GLWEInfos + BSGSMeta + CKKSCtBounds,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 }
 
 impl<BE: Backend> PolynomialEvaluationDefault<BE> for Module<BE> {
@@ -212,7 +212,7 @@ impl<BE: Backend> PolynomialEvaluationDefault<BE> for Module<BE> {
         B::Coeffs: CKKSCtBounds,
         A: GLWEToBackendRef<BE> + GLWEInfos + BSGSMeta + CKKSCtBounds,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         ckks_ensure!(
             poly.baby_steps() > 0,
@@ -289,7 +289,7 @@ impl<BE: Backend> PolynomialEvaluationDefault<BE> for Module<BE> {
         C: GLWEToBackendRef<BE> + GLWEInfos + BSGSMeta + CKKSCtBounds + IntPolyInfos,
         A: GLWEToBackendRef<BE> + GLWEInfos + BSGSMeta + CKKSCtBounds,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         let poly_re = &poly.re;
         let poly_im = &poly.im;

--- a/poulpy-ckks/src/delegates/bootstrapping.rs
+++ b/poulpy-ckks/src/delegates/bootstrapping.rs
@@ -15,6 +15,7 @@ use crate::{
         CKKSEvalModOps, CKKSImagOps, CKKSMulOps, CKKSPolynomialEvaluationOps, CKKSPow2Ops, CKKSSubOps,
     },
     default::bootstrapping::BootstrappingDefault,
+    layouts::EvalModPlan,
     layouts::{
         BootstrappingContext, BootstrappingKeys, BootstrappingKeysLayout, CKKSCiphertextOwned, CKKSModuleAlloc,
         CKKSPlaintextOwned, EncodedLut,
@@ -77,12 +78,41 @@ where
         BootstrappingDefault::new(self).ckks_functional_bootstrap_tmp_bytes_default(ct_out, ct_in, ctx, luts, keys_layout)
     }
 
-    fn ckks_mod_up_into<Dst, Src>(&self, dst: &mut Dst, src: &Src, scratch: &mut ScratchArena<'_, BE>) -> Result<()>
+    fn ckks_mod_up_into<Dst, Src>(
+        &self,
+        dst: &mut Dst,
+        src: &Src,
+        eval_mod: &EvalModPlan,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) -> Result<()>
     where
         Dst: GLWEToBackendMut<BE> + CKKSCtBounds + SetCKKSInfos,
         Src: GLWEToBackendRef<BE> + CKKSCtBounds,
     {
-        BootstrappingDefault::new(self).ckks_mod_up_into_default(dst, src, scratch)
+        let scale_up = eval_mod.raised_scale_up(src.log_delta())?;
+        BootstrappingDefault::new(self).ckks_mod_up_into_default(dst, src, scale_up, scratch)?;
+        // Relabel by the message ratio here, so callers never have to stamp
+        // metadata by hand after the call.
+        let mut meta = dst.meta();
+        meta.log_delta += eval_mod.log_msg_ratio;
+        dst.set_meta(meta);
+        Ok(())
+    }
+
+    fn ckks_bootstrap_mod_up<Dst, Src, K>(
+        &self,
+        dst: &mut Dst,
+        src: &Src,
+        eval_mod: &EvalModPlan,
+        keys: &K,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) -> Result<()>
+    where
+        Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
+        Src: GLWEToBackendRef<BE> + CKKSCtBounds,
+        K: BootstrappingKeys<BE>,
+    {
+        BootstrappingDefault::new(self).ckks_bootstrap_mod_up_default(dst, src, eval_mod, keys, scratch)
     }
 
     fn ckks_bootstrap<F, K>(

--- a/poulpy-ckks/src/delegates/composite.rs
+++ b/poulpy-ckks/src/delegates/composite.rs
@@ -143,7 +143,9 @@ where
         Dst: GLWEToBackendMut<BE> + CKKSCtBounds + SetCKKSInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds,
         B: GLWEToBackendRef<BE> + CKKSCtBounds,
-        T: GGLWEInfos + poulpy_core::layouts::prepared::GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos
+            + poulpy_core::layouts::prepared::GLWETensorKeyPreparedToBackendRef<BE>
+            + poulpy_core::layouts::prepared::GGLWEPreparedToBackendRef<BE>,
     {
         mul_then_combine(
             dst,
@@ -371,7 +373,9 @@ where
         Dst: GLWEToBackendMut<BE> + CKKSCtBounds + SetCKKSInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds,
         B: GLWEToBackendRef<BE> + CKKSCtBounds,
-        T: GGLWEInfos + poulpy_core::layouts::prepared::GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos
+            + poulpy_core::layouts::prepared::GLWETensorKeyPreparedToBackendRef<BE>
+            + poulpy_core::layouts::prepared::GGLWEPreparedToBackendRef<BE>,
     {
         mul_then_combine(
             dst,
@@ -524,7 +528,8 @@ where
         CKKSCiphertext<Dst, BE::ZnxWord>: GLWEToBackendMut<BE>,
         CKKSCiphertext<D, BE::ZnxWord>: GLWEToBackendRef<BE> + GLWEInfos,
         CKKSCiphertext<E, BE::ZnxWord>: GLWEToBackendRef<BE> + GLWEInfos,
-        GLWETensorKeyPrepared<T, BE>: poulpy_core::layouts::prepared::GLWETensorKeyPreparedToBackendRef<BE>,
+        GLWETensorKeyPrepared<T, BE>: poulpy_core::layouts::prepared::GLWETensorKeyPreparedToBackendRef<BE>
+            + poulpy_core::layouts::prepared::GGLWEPreparedToBackendRef<BE>,
     {
         check_lengths("ckks_dot_product_ct", a.len(), b.len())?;
         let n: usize = a.len();

--- a/poulpy-ckks/src/delegates/mul.rs
+++ b/poulpy-ckks/src/delegates/mul.rs
@@ -2,7 +2,10 @@ use crate::CKKSResult as Result;
 use poulpy_core::layouts::IntPolyInfos;
 use poulpy_core::{
     GLWEAdd, GLWECopy, GLWEMulConst, GLWEMulPlain, GLWERotate, GLWETensoring,
-    layouts::{GGLWEInfos, GLWEToBackendMut, GLWEToBackendRef, ModuleCoreAlloc, prepared::GLWETensorKeyPreparedToBackendRef},
+    layouts::{
+        GGLWEInfos, GLWEToBackendMut, GLWEToBackendRef, ModuleCoreAlloc,
+        prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPreparedToBackendRef},
+    },
 };
 use poulpy_hal::{
     api::{ModuleN, VecZnxCopyBackend},
@@ -67,7 +70,7 @@ where
         Dst: GLWEToBackendMut<BE> + CKKSCtBounds + SetCKKSInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds,
         B: GLWEToBackendRef<BE> + CKKSCtBounds,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         BE::ckks_mul_into_impl(self, dst, a, b, tsk, scratch)
     }
@@ -76,7 +79,7 @@ where
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         BE::ckks_mul_assign_impl(self, dst, a, tsk, scratch)
     }
@@ -97,7 +100,7 @@ where
     ) -> Result<()>
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         BE::ckks_mul_prepared_assign_impl(self, dst, prepared, tsk, scratch)
     }
@@ -106,7 +109,7 @@ where
     where
         Dst: GLWEToBackendMut<BE> + CKKSCtBounds + SetCKKSInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         BE::ckks_square_into_impl(self, dst, a, tsk, scratch)
     }
@@ -114,7 +117,7 @@ where
     fn ckks_square_assign<Dst, T>(&self, dst: &mut Dst, tsk: &T, scratch: &mut ScratchArena<'_, BE>) -> Result<()>
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSCtBounds + SetCKKSInfos,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         BE::ckks_square_assign_impl(self, dst, tsk, scratch)
     }

--- a/poulpy-ckks/src/delegates/polynomial_evaluation.rs
+++ b/poulpy-ckks/src/delegates/polynomial_evaluation.rs
@@ -2,7 +2,7 @@ use crate::CKKSResult as Result;
 use poulpy_core::layouts::IntPolyInfos;
 use poulpy_core::layouts::{
     BSGSMeta, GGLWEInfos, GLWEInfos, GLWEToBackendMut, GLWEToBackendRef, ModuleCoreAlloc, SetBSGSMeta,
-    prepared::{GLWETensorKeyPrepared, GLWETensorKeyPreparedToBackendRef},
+    prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPrepared, GLWETensorKeyPreparedToBackendRef},
 };
 use poulpy_hal::layouts::{Backend, Module, ScratchArena};
 
@@ -32,7 +32,7 @@ where
         B::Coeffs: CKKSCtBounds,
         A: GLWEToBackendRef<BE> + CKKSCtBounds + BSGSMeta,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         BE::ckks_eval_poly_real_const_coeffs_from_power_basis_impl::<R, B, A, G, T>(self, res, poly, power_basis, tsk, scratch)
     }
@@ -50,7 +50,7 @@ where
         C: GLWEToBackendRef<BE> + GLWEInfos + BSGSMeta + CKKSCtBounds + IntPolyInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds + BSGSMeta,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         BE::ckks_eval_poly_complex_const_coeffs_from_power_basis_impl::<R, C, A, G, T>(self, res, poly, power_basis, tsk, scratch)
     }

--- a/poulpy-ckks/src/layouts/bootstrapping_keys.rs
+++ b/poulpy-ckks/src/layouts/bootstrapping_keys.rs
@@ -70,7 +70,7 @@ pub trait BootstrappingKeys<BE: Backend> {
     type RotationKeys: GLWEAutomorphismKeyHelper<Self::AutomorphismKey, BE>;
 
     /// The prepared tensor (relinearization) key type for EvalMod.
-    type TensorKey: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos;
+    type TensorKey: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos;
 
     /// The prepared key-switching key type for sparse-secret encapsulation.
     type SwitchingKey: GGLWEPreparedToBackendRef<BE> + GGLWEInfos;
@@ -125,7 +125,7 @@ pub struct BootstrappingKeysPrepared<D: Data, BE: Backend> {
 impl<D: Data, BE: Backend> BootstrappingKeys<BE> for BootstrappingKeysPrepared<D, BE>
 where
     GLWEAutomorphismKeyPrepared<D, BE>: CKKSAtkBounds<BE>,
-    GLWETensorKeyPrepared<D, BE>: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+    GLWETensorKeyPrepared<D, BE>: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     GLWESwitchingKeyPrepared<D, BE>: GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
 {
     type AutomorphismKey = GLWEAutomorphismKeyPrepared<D, BE>;

--- a/poulpy-ckks/src/layouts/eval_mod.rs
+++ b/poulpy-ckks/src/layouts/eval_mod.rs
@@ -192,6 +192,31 @@ impl EvalModPlan {
         }
     }
 
+    /// Bits `Δ·m` must be lifted by, at the input modulus `2^k`, for a ciphertext
+    /// of scale `log_delta` to carry exactly this plan's message ratio. Errors if
+    /// the input cannot reach that ratio.
+    pub(crate) fn input_scale_up(&self, k: usize, log_delta: usize) -> Result<usize> {
+        let log_msg_ratio = self.log_msg_ratio;
+        ensure!(
+            k >= log_delta + log_msg_ratio,
+            "EvalModPlan: input k ({k}) < log_delta ({log_delta}) + log_msg_ratio ({log_msg_ratio})"
+        );
+        Ok(k - log_delta - log_msg_ratio)
+    }
+
+    /// Bits the raised ciphertext must be lifted by, on top of a ModUp from a
+    /// modulus of scale `log_delta`, to reach this plan's own scale. Errors if the
+    /// plan's scale sits below the modulus it would have to lift from.
+    pub(crate) fn raised_scale_up(&self, log_delta: usize) -> Result<usize> {
+        let f_mod_log_delta = self.f_mod_log_delta;
+        let log_msg_ratio = self.log_msg_ratio;
+        ensure!(
+            f_mod_log_delta >= log_delta + log_msg_ratio,
+            "EvalModPlan: f_mod_log_delta ({f_mod_log_delta}) < log_delta ({log_delta}) + log_msg_ratio ({log_msg_ratio})"
+        );
+        Ok(f_mod_log_delta - log_delta - log_msg_ratio)
+    }
+
     /// Multiplicative levels the eval_mod pipeline consumes: BSGS depth of the
     /// base `f` polynomial + `f_mod_log_interval_reduction` range-extension steps
     /// + BSGS depth of the optional inverse `f⁻¹` post-composition.

--- a/poulpy-ckks/src/layouts/paco/keyset.rs
+++ b/poulpy-ckks/src/layouts/paco/keyset.rs
@@ -112,7 +112,7 @@ pub trait PaCoKeys<BE: Backend> {
     type RotationKeys: GLWEAutomorphismKeyHelper<Self::AutomorphismKey, BE>;
 
     /// Prepared tensor (relinearization) key used by the product fold.
-    type TensorKey: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos;
+    type TensorKey: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos;
 
     /// Prepared dense-to-PaCo switching key used by optional encapsulation.
     type SwitchingKey: GGLWEPreparedToBackendRef<BE> + GGLWEInfos + GLWESwitchingKeyDegrees;
@@ -514,7 +514,7 @@ impl<D: Data, BE: Backend> PaCoKeys<BE> for PaCoKeysPrepared<D, BE>
 where
     CKKSCiphertext<D, BE::ZnxWord>: GLWEToBackendRef<BE> + CKKSCtBounds,
     GLWEAutomorphismKeyPrepared<D, BE>: CKKSAtkBounds<BE>,
-    GLWETensorKeyPrepared<D, BE>: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+    GLWETensorKeyPrepared<D, BE>: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     GLWESwitchingKeyPrepared<D, BE>: GGLWEPreparedToBackendRef<BE> + GGLWEInfos + GLWESwitchingKeyDegrees,
 {
     type BootstrappingKey = CKKSCiphertext<D, BE::ZnxWord>;

--- a/poulpy-ckks/src/oep/bootstrapping.rs
+++ b/poulpy-ckks/src/oep/bootstrapping.rs
@@ -31,10 +31,14 @@ pub unsafe trait CKKSEncapsulatedModUpImpl<BE: Backend>: Backend {
         D2S: GGLWEInfos,
         S2D: GGLWEInfos;
 
+    /// `scale_up` is applied to the raised ciphertext between ModUp and the
+    /// sparse-to-dense switch, so the message is already at its final scale when
+    /// that key-switch's noise is added.
     fn ckks_encapsulated_mod_up<Dst, Src, D2S, S2D>(
         module: &Module<BE>,
         dst: &mut Dst,
         src: &mut Src,
+        scale_up: usize,
         dense_to_sparse: &D2S,
         sparse_to_dense: &S2D,
         scratch: &mut ScratchArena<'_, BE>,
@@ -77,6 +81,7 @@ macro_rules! impl_ckks_encapsulated_mod_up_default {
                 module: &::poulpy_hal::layouts::Module<$be>,
                 dst: &mut Dst,
                 src: &mut Src,
+                scale_up: usize,
                 dense_to_sparse: &D2S,
                 sparse_to_dense: &S2D,
                 scratch: &mut ::poulpy_hal::layouts::ScratchArena<'_, $be>,
@@ -97,6 +102,7 @@ macro_rules! impl_ckks_encapsulated_mod_up_default {
                     module,
                     dst,
                     src,
+                    scale_up,
                     dense_to_sparse,
                     sparse_to_dense,
                     scratch,

--- a/poulpy-ckks/src/oep/mul.rs
+++ b/poulpy-ckks/src/oep/mul.rs
@@ -4,7 +4,10 @@ use poulpy_core::layouts::IntPolyInfos;
 
 use poulpy_core::{
     GLWEAdd, GLWECopy, GLWEMulConst, GLWEMulPlain, GLWERotate, GLWETensoring, GiantStepTensorBounds,
-    layouts::{GGLWEInfos, GLWEInfos, LWEInfos, ModuleCoreAlloc, TorusPrecision, prepared::GLWETensorKeyPreparedToBackendRef},
+    layouts::{
+        GGLWEInfos, GLWEInfos, LWEInfos, ModuleCoreAlloc, TorusPrecision,
+        prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPreparedToBackendRef},
+    },
 };
 use poulpy_hal::{
     api::{CnvPVecAlloc, VecZnxCopyBackend},
@@ -56,7 +59,7 @@ pub unsafe trait CKKSMulImpl<BE: Backend>: Backend {
         Dst: GLWEToBackendMut<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
         A: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
         B: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos;
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos;
     fn ckks_mul_assign_impl<Dst, A, T>(
         module: &Module<BE>,
         dst: &mut Dst,
@@ -67,7 +70,7 @@ pub unsafe trait CKKSMulImpl<BE: Backend>: Backend {
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
         A: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos;
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos;
     fn ckks_prepare_right_impl<A>(
         module: &Module<BE>,
         a: &A,
@@ -84,7 +87,7 @@ pub unsafe trait CKKSMulImpl<BE: Backend>: Backend {
     ) -> Result<()>
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos;
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos;
     fn ckks_square_into_impl<Dst, A, T>(
         module: &Module<BE>,
         dst: &mut Dst,
@@ -95,7 +98,7 @@ pub unsafe trait CKKSMulImpl<BE: Backend>: Backend {
     where
         Dst: GLWEToBackendMut<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
         A: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos;
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos;
     fn ckks_square_assign_impl<Dst, T>(
         module: &Module<BE>,
         dst: &mut Dst,
@@ -104,7 +107,7 @@ pub unsafe trait CKKSMulImpl<BE: Backend>: Backend {
     ) -> Result<()>
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos;
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos;
     fn ckks_mul_pt_vec_into_impl<Dst, A, P>(
         module: &Module<BE>,
         dst: &mut Dst,
@@ -213,7 +216,7 @@ where
         Dst: GLWEToBackendMut<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
         A: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
         B: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         module.ckks_mul_into_default(dst, a, b, tsk, scratch)
     }
@@ -228,7 +231,7 @@ where
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
         A: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         module.ckks_mul_assign_default(dst, a, tsk, scratch)
     }
@@ -249,7 +252,7 @@ where
     ) -> Result<()>
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         module.ckks_mul_prepared_assign_default(dst, prepared, tsk, scratch)
     }
@@ -264,7 +267,7 @@ where
     where
         Dst: GLWEToBackendMut<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
         A: GLWEToBackendRef<BE> + CKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         module.ckks_square_into_default(dst, a, tsk, scratch)
     }
@@ -277,7 +280,7 @@ where
     ) -> Result<()>
     where
         Dst: GLWEToBackendMut<BE> + GLWEToBackendRef<BE> + CKKSInfos + SetCKKSInfos + GLWEInfos,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         module.ckks_square_assign_default(dst, tsk, scratch)
     }

--- a/poulpy-ckks/src/oep/polynomial_evaluation.rs
+++ b/poulpy-ckks/src/oep/polynomial_evaluation.rs
@@ -2,7 +2,7 @@ use crate::{CKKSResult as Result, ckks_ensure};
 use poulpy_core::layouts::IntPolyInfos;
 use poulpy_core::layouts::{
     GGLWEInfos, GLWEInfos, GLWEToBackendMut, GLWEToBackendRef, SetBSGSMeta,
-    prepared::{GLWETensorKeyPrepared, GLWETensorKeyPreparedToBackendRef},
+    prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPrepared, GLWETensorKeyPreparedToBackendRef},
 };
 use poulpy_core::{
     GLWEAdd, GLWECopy, GLWEMulConst, GLWENormalize, GLWEPolynomialEvaluation, GLWEShift, GLWETensoring, GLWEZero,
@@ -81,7 +81,7 @@ pub unsafe trait CKKSPolynomialEvaluationImpl<BE: Backend>: Backend {
         B::Coeffs: CKKSCtBounds,
         A: GLWEToBackendRef<BE> + CKKSCtBounds + poulpy_core::layouts::BSGSMeta,
         G: PowerBasisHelper<BE, A>,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos;
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos;
 
     fn ckks_eval_poly_complex_const_coeffs_from_power_basis_impl<R, C, A, G, T>(
         module: &Module<BE>,
@@ -96,7 +96,7 @@ pub unsafe trait CKKSPolynomialEvaluationImpl<BE: Backend>: Backend {
         C: GLWEToBackendRef<BE> + GLWEInfos + poulpy_core::layouts::BSGSMeta + CKKSCtBounds + IntPolyInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds + poulpy_core::layouts::BSGSMeta,
         G: PowerBasisHelper<BE, A>,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos;
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos;
 
     fn ckks_eval_poly_real_const_coeffs_impl<R, S, B>(
         module: &Module<BE>,
@@ -165,7 +165,7 @@ where
         B::Coeffs: CKKSCtBounds,
         A: GLWEToBackendRef<BE> + CKKSCtBounds + poulpy_core::layouts::BSGSMeta,
         G: PowerBasisHelper<BE, A>,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         module.ckks_eval_poly_real_const_coeffs_from_power_basis_default::<R, B, A, G, T>(res, poly, power_basis, tsk, scratch)
     }
@@ -183,7 +183,7 @@ where
         C: GLWEToBackendRef<BE> + GLWEInfos + poulpy_core::layouts::BSGSMeta + CKKSCtBounds + IntPolyInfos,
         A: GLWEToBackendRef<BE> + CKKSCtBounds + poulpy_core::layouts::BSGSMeta,
         G: PowerBasisHelper<BE, A>,
-        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEInfos,
+        T: GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE> + GGLWEInfos,
     {
         module.ckks_eval_poly_complex_const_coeffs_from_power_basis_default::<R, C, A, G, T>(res, poly, power_basis, tsk, scratch)
     }

--- a/poulpy-ckks/src/test_suite/bootstrapping.rs
+++ b/poulpy-ckks/src/test_suite/bootstrapping.rs
@@ -34,12 +34,9 @@ use crate::layouts::CKKSCiphertextOwned;
 use crate::layouts::CKKSPlaintextOwned;
 use std::time::Instant;
 
-use poulpy_core::{
-    GLWEKeyswitch,
-    layouts::{
-        GGLWEInfos, GLWEInfos, GLWESecretPreparedToBackendRef, GLWETensorKeyPrepared, GLWEToBackendMut, GLWEToBackendRef,
-        LWEInfos, prepared::GLWETensorKeyPreparedToBackendRef,
-    },
+use poulpy_core::layouts::{
+    GGLWEInfos, GLWEInfos, GLWESecretPreparedToBackendRef, GLWETensorKeyPrepared, GLWEToBackendMut, GLWEToBackendRef, LWEInfos,
+    prepared::GLWETensorKeyPreparedToBackendRef,
 };
 use poulpy_hal::{
     api::{NegacyclicFFT, NegacyclicFFTNew, ScratchOwnedAlloc, ScratchOwnedBorrow},
@@ -285,7 +282,7 @@ pub fn test_bootstrapping_standard_e2e<BE, F, E>(
         (rr, ri)
     };
 
-    let mut ct0 = ckks_encrypt_with_prec(
+    let ct0 = ckks_encrypt_with_prec(
         &tp,
         &module,
         &host_module,
@@ -349,24 +346,16 @@ pub fn test_bootstrapping_standard_e2e<BE, F, E>(
     }
 
     let now = Instant::now();
-    // 1) (encapsulate) denseToSparse, ModUp, sparseToDense — so the integer
-    //    wrap-around `I(X)·q` ModUp exposes is bounded by the *sparse* secret's
-    //    Hamming weight. Then relabel at the input-modulus scale (free
-    //    /message-ratio): `I(X)·q` becomes the integer part, the message the
+    // 1) The whole raise step: lift to the plan's message ratio, (encapsulate)
+    //    denseToSparse / ModUp / sparseToDense so the integer wrap-around `I(X)·q`
+    //    is bounded by the *sparse* secret's Hamming weight, and relabel by the
+    //    message ratio: `I(X)·q` becomes the integer part, the message the
     //    residue `Δ·c/q`.
-    if let Some((dense_to_sparse, _)) = bsk.encapsulation_keys() {
-        module.glwe_keyswitch_assign(&mut ct0, dense_to_sparse, &mut scratch.borrow());
-    }
-    println!("denseToSparse: {:?}", now.elapsed());
-
-    let now = Instant::now();
     let mut ct = module.ckks_ciphertext_alloc(base2k.into(), k_boot.into());
-    module.ckks_mod_up_into(&mut ct, &ct0, &mut scratch.borrow()).unwrap();
-    if let Some((_, sparse_to_dense)) = bsk.encapsulation_keys() {
-        module.glwe_keyswitch_assign(&mut ct, sparse_to_dense, &mut scratch.borrow());
-    }
-    ct.set_meta(meta(log_modulus_in, k_boot - log_modulus_in).meta);
-    println!("ckks_mod_up_into: {:?}", now.elapsed());
+    module
+        .ckks_bootstrap_mod_up(&mut ct, &ct0, plan.eval_mod(), &bsk, &mut scratch.borrow())
+        .unwrap();
+    println!("ckks_bootstrap_mod_up: {:?}", now.elapsed());
 
     let mut log_budget_check = k_boot - ct.log_delta();
 
@@ -702,7 +691,7 @@ pub fn test_bootstrapping_evalround_e2e<BE, F, E>(
 
     let (re, im) = test_vector_1::<F>(m);
 
-    let mut ct0 = ckks_encrypt_with_prec(
+    let ct0 = ckks_encrypt_with_prec(
         &tp,
         &module,
         &host_module,
@@ -765,16 +754,12 @@ pub fn test_bootstrapping_evalround_e2e<BE, F, E>(
         assert!(precision_stats(&im_bs, &im_zero, log_delta).avg_log2_prec >= 5.0);
     }
 
-    // 1) (encapsulate) denseToSparse, ModUp, sparseToDense.
-    if let Some((dense_to_sparse, _)) = bsk.encapsulation_keys() {
-        module.glwe_keyswitch_assign(&mut ct0, dense_to_sparse, &mut scratch.borrow());
-    }
+    // 1) The whole raise step: lift, (encapsulate) denseToSparse / ModUp /
+    //    sparseToDense, relabel by the message ratio.
     let mut ct = module.ckks_ciphertext_alloc(base2k.into(), k_boot.into());
-    module.ckks_mod_up_into(&mut ct, &ct0, &mut scratch.borrow()).unwrap();
-    if let Some((_, sparse_to_dense)) = bsk.encapsulation_keys() {
-        module.glwe_keyswitch_assign(&mut ct, sparse_to_dense, &mut scratch.borrow());
-    }
-    ct.set_meta(meta(log_modulus_in, k_boot - log_modulus_in).meta);
+    module
+        .ckks_bootstrap_mod_up(&mut ct, &ct0, plan.eval_mod(), &bsk, &mut scratch.borrow())
+        .unwrap();
 
     // 2) CoeffsToSlots (split): LP (low precision, `1/K` scaling) for the round, and
     //    HP (full precision, natural scaling) for the high-precision `Δm + I·q`.

--- a/poulpy-core/src/api/operations.rs
+++ b/poulpy-core/src/api/operations.rs
@@ -146,7 +146,7 @@ pub trait GLWETensoring<BE: Backend> {
     where
         R: GLWEToBackendMut<BE> + GLWEInfos,
         A: GLWEToBackendRef<BE> + GLWEInfos,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     fn glwe_tensor_relinearize_tmp_bytes<R, A, B>(&self, res: &R, a: &A, tsk: &B) -> usize
     where

--- a/poulpy-core/src/api/polynomial_evaluation.rs
+++ b/poulpy-core/src/api/polynomial_evaluation.rs
@@ -5,7 +5,7 @@ use crate::{
     BSGSOps,
     layouts::{
         BabyStep, GGLWEInfos, GLWEInfos, GLWEToBackendMut, GLWEToBackendRef, Parity, PowerBasisHelper,
-        prepared::GLWETensorKeyPreparedToBackendRef,
+        prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPreparedToBackendRef},
     },
 };
 
@@ -50,5 +50,5 @@ pub trait GLWEPolynomialEvaluation<BE: Backend> {
         P: GLWEToBackendRef<BE>,
         A: GLWEToBackendRef<BE>,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 }

--- a/poulpy-core/src/default/polynomial_evaluation.rs
+++ b/poulpy-core/src/default/polynomial_evaluation.rs
@@ -20,7 +20,7 @@ use poulpy_hal::{
 use crate::{
     layouts::{
         BabyStep, GGLWEInfos, GLWEInfos, GLWEToBackendMut, GLWEToBackendRef, Parity, PowerBasisHelper,
-        prepared::GLWETensorKeyPreparedToBackendRef,
+        prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPreparedToBackendRef},
     },
     oep::PolynomialEvaluationDefault,
 };
@@ -127,7 +127,7 @@ where
         scratch: &mut ScratchArena<'_, BE>,
     ) -> Result<()>
     where
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     /// Computes `dst += a` with budget alignment, normalizing `dst`.
     fn add_assign(&self, module: &Module<BE>, dst: &mut V, a: &V, scratch: &mut ScratchArena<'_, BE>) -> Result<()>;
@@ -204,7 +204,7 @@ where
     P: GLWEToBackendRef<BE>,
     A: GLWEToBackendRef<BE>,
     G: PowerBasisHelper<BE, A>,
-    T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+    T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
 {
     ensure!(
         !baby_steps.is_empty(),
@@ -318,7 +318,7 @@ impl<BE: Backend> PolynomialEvaluationDefault<BE> for Module<BE> {
         P: GLWEToBackendRef<BE>,
         A: GLWEToBackendRef<BE>,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         eval_giant_steps::<R, B, V, P, A, G, T, BE, Ops>(self, ops, res, baby_steps, power_basis, tsk, scratch)
     }

--- a/poulpy-core/src/delegates/operations.rs
+++ b/poulpy-core/src/delegates/operations.rs
@@ -240,7 +240,7 @@ impl_operations_delegate!(
     where
         R: GLWEToBackendMut<BE> + GLWEInfos,
         A: GLWEToBackendRef<BE> + GLWEInfos,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         BE::glwe_tensor_relinearize(self, res, a, tsk, scratch)
     },

--- a/poulpy-core/src/delegates/polynomial_evaluation.rs
+++ b/poulpy-core/src/delegates/polynomial_evaluation.rs
@@ -5,7 +5,7 @@ use crate::{
     BSGSOps, GLWEPolynomialEvaluation,
     layouts::{
         BabyStep, GGLWEInfos, GLWEInfos, GLWEToBackendMut, GLWEToBackendRef, Parity, PowerBasisHelper,
-        prepared::GLWETensorKeyPreparedToBackendRef,
+        prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPreparedToBackendRef},
     },
     oep::PolynomialEvaluationImpl,
 };
@@ -47,7 +47,7 @@ impl<BE: Backend + PolynomialEvaluationImpl<BE>> GLWEPolynomialEvaluation<BE> fo
         P: GLWEToBackendRef<BE>,
         A: GLWEToBackendRef<BE>,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         BE::glwe_eval_giant_steps::<Ops, R, B, V, P, A, G, T>(self, ops, res, baby_steps, power_basis, tsk, scratch)
     }

--- a/poulpy-core/src/layouts/prepared/glwe_tensor_key.rs
+++ b/poulpy-core/src/layouts/prepared/glwe_tensor_key.rs
@@ -2,8 +2,8 @@ use poulpy_hal::layouts::{Backend, Data, Module, ScratchArena};
 
 use crate::layouts::prepared::{GGLWEPreparedToBackendMut, GGLWEPreparedToBackendRef};
 use crate::layouts::{
-    Base2K, Degree, Dnum, Dsize, GGLWEInfos, GGLWEPrepared, GGLWEPreparedBackendMut, GGLWEPreparedFactory, GGLWEToBackendRef,
-    GLWEInfos, LWEInfos, Rank, TorusPrecision,
+    Base2K, Degree, Dnum, Dsize, GGLWEInfos, GGLWEPrepared, GGLWEPreparedBackendMut, GGLWEPreparedBackendRef,
+    GGLWEPreparedFactory, GGLWEToBackendRef, GLWEInfos, LWEInfos, Rank, TorusPrecision,
 };
 
 /// DFT-domain (prepared) variant of a GLWE tensor key.
@@ -155,6 +155,15 @@ where
 {
     fn to_backend_mut(&mut self) -> GLWETensorKeyPreparedBackendMut<'_, B> {
         GLWETensorKeyPrepared(self.0.to_backend_mut())
+    }
+}
+
+impl<D: Data, B: Backend> GGLWEPreparedToBackendRef<B> for GLWETensorKeyPrepared<D, B>
+where
+    GGLWEPrepared<D, B>: GGLWEPreparedToBackendRef<B>,
+{
+    fn to_backend_ref(&self) -> GGLWEPreparedBackendRef<'_, B> {
+        self.0.to_backend_ref()
     }
 }
 

--- a/poulpy-core/src/oep/operations.rs
+++ b/poulpy-core/src/oep/operations.rs
@@ -132,7 +132,7 @@ pub unsafe trait GLWETensoringImpl<BE: Backend>: Backend {
     where
         R: GLWEToBackendMut<BE> + GLWEInfos,
         A: GLWEToBackendRef<BE> + GLWEInfos,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 
     fn glwe_tensor_relinearize_tmp_bytes<R, A, B>(module: &Module<BE>, res: &R, a: &A, tsk: &B) -> usize
     where

--- a/poulpy-core/src/oep/polynomial_evaluation.rs
+++ b/poulpy-core/src/oep/polynomial_evaluation.rs
@@ -5,7 +5,7 @@ use crate::{
     default::polynomial_evaluation::BSGSOps,
     layouts::{
         BabyStep, GGLWEInfos, GLWEInfos, GLWEToBackendMut, GLWEToBackendRef, Parity, PowerBasisHelper,
-        prepared::GLWETensorKeyPreparedToBackendRef,
+        prepared::{GGLWEPreparedToBackendRef, GLWETensorKeyPreparedToBackendRef},
     },
 };
 
@@ -50,7 +50,7 @@ pub unsafe trait PolynomialEvaluationImpl<BE: Backend>: Backend {
         P: GLWEToBackendRef<BE>,
         A: GLWEToBackendRef<BE>,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 }
 
 /// Override surface carrying the reference BSGS phase implementations.
@@ -89,7 +89,7 @@ pub trait PolynomialEvaluationDefault<BE: Backend> {
         P: GLWEToBackendRef<BE>,
         A: GLWEToBackendRef<BE>,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>;
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>;
 }
 
 unsafe impl<BE: Backend> PolynomialEvaluationImpl<BE> for BE
@@ -132,7 +132,7 @@ where
         P: GLWEToBackendRef<BE>,
         A: GLWEToBackendRef<BE>,
         G: PowerBasisHelper<BE, A>,
-        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE>,
+        T: GGLWEInfos + GLWETensorKeyPreparedToBackendRef<BE> + GGLWEPreparedToBackendRef<BE>,
     {
         module.glwe_eval_giant_steps_default::<Ops, R, B, V, P, A, G, T>(ops, res, baby_steps, power_basis, tsk, scratch)
     }


### PR DESCRIPTION
- ModUp lifts `Δ·m` to `k - log_msg_ratio`, then to `f_mod_log_delta` fused into the widening shift, both before the sparse-to-dense switch. Recovers `f_mod_log_delta - k` bits (19.7 → 26.9 at `LogN=16`, `Δ=2^40`, ratio `2^8`). C2S-first only.
- **Breaking:** `ckks_mod_up_into` takes `&EvalModPlan` and returns a labelled ciphertext; new `ckks_bootstrap_mod_up` does the whole raise step; `CKKSEncapsulatedModUpImpl::ckks_encapsulated_mod_up` takes `scale_up`.

This brings Poulpy in line with the expected precision and with Lattigo.