### PR TITLE
Jdmz/rayon hal

### DIFF
--- a/poulpy-core/src/tests/scratch_arena.rs
+++ b/poulpy-core/src/tests/scratch_arena.rs
@@ -15,6 +15,7 @@ use crate::{
 struct TestBackend;
 
 impl Backend for TestBackend {
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type ZnxWord = i64;
     type BigWord = i64;
     type DftWord = f64;

--- a/poulpy-core/src/tests/transfer.rs
+++ b/poulpy-core/src/tests/transfer.rs
@@ -21,6 +21,7 @@ fn host_alloc(len: usize) -> Vec<u8> {
 }
 
 impl Backend for SrcBackend {
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type ZnxWord = i64;
     type BigWord = i64;
     type DftWord = f64;
@@ -140,6 +141,7 @@ unsafe impl HalModuleImpl<SrcBackend> for SrcBackend {
 }
 
 impl Backend for DstBackend {
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type ZnxWord = i64;
     type BigWord = i64;
     type DftWord = f64;

--- a/poulpy-cpu-arm/src/fft64/module.rs
+++ b/poulpy-cpu-arm/src/fft64/module.rs
@@ -20,7 +20,10 @@ pub struct FFT64NeonHandle {
     table_cache: ::poulpy_cpu_ref::table_cache::ModuleTableCache,
 }
 
+impl poulpy_hal::execution::ScratchWorkers for FFT64Neon {}
+
 impl Backend for FFT64Neon {
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type DftWord = f64;
     type ZnxWord = i64;
     type BigWord = i64;

--- a/poulpy-cpu-arm/src/hal_impl.rs
+++ b/poulpy-cpu-arm/src/hal_impl.rs
@@ -280,6 +280,34 @@ unsafe impl HalConvolutionImpl<NTT4x30Neon> for NTT4x30Neon {
     }
 
     #[allow(clippy::too_many_arguments)]
+    fn cnv_by_const_apply_add(
+        module: &Module<Self>,
+        cnv_offset: usize,
+        mut res: &mut poulpy_hal::layouts::VecZnxBigBackendMut<'_, Self>,
+        res_col: usize,
+        a: &VecZnxBackendRef<'_, Self>,
+        a_col: usize,
+        b: &VecZnxBackendRef<'_, Self>,
+        b_col: usize,
+        b_coeff: usize,
+        scratch: &mut ScratchArena<'_, Self>,
+    ) {
+        let mut scratch = scratch.borrow();
+        <Self as NTT4x30ConvolutionDefault<Self>>::cnv_by_const_apply_add_default(
+            module,
+            cnv_offset,
+            &mut res,
+            res_col,
+            a,
+            a_col,
+            b,
+            b_col,
+            b_coeff,
+            &mut scratch,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn cnv_apply_dft(
         module: &Module<Self>,
         cnv_offset: usize,

--- a/poulpy-cpu-arm/src/ntt4x30/module.rs
+++ b/poulpy-cpu-arm/src/ntt4x30/module.rs
@@ -27,9 +27,12 @@ pub struct NTT4x30NeonHandle {
     table_cache: ::poulpy_cpu_ref::table_cache::ModuleTableCache,
 }
 
+impl poulpy_hal::execution::ScratchWorkers for NTT4x30Neon {}
+
 impl Backend for NTT4x30Neon {
     const DFT_IS_EXACT: bool = true;
 
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type DftWord = Q120bScalar;
     type ZnxWord = i64;
     type BigWord = i128;

--- a/poulpy-cpu-avx/src/fft64/module.rs
+++ b/poulpy-cpu-avx/src/fft64/module.rs
@@ -83,7 +83,10 @@ pub struct FFT64AvxHandle {
     table_cache: ::poulpy_cpu_ref::table_cache::ModuleTableCache,
 }
 
+impl poulpy_hal::execution::ScratchWorkers for FFT64Avx {}
+
 impl Backend for FFT64Avx {
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type DftWord = f64;
     type ZnxWord = i64;
     type BigWord = i64;

--- a/poulpy-cpu-avx/src/hal_impl.rs
+++ b/poulpy-cpu-avx/src/hal_impl.rs
@@ -292,6 +292,34 @@ unsafe impl HalConvolutionImpl<NTT4x30Avx> for NTT4x30Avx {
     }
 
     #[allow(clippy::too_many_arguments)]
+    fn cnv_by_const_apply_add(
+        module: &Module<Self>,
+        cnv_offset: usize,
+        mut res: &mut poulpy_hal::layouts::VecZnxBigBackendMut<'_, Self>,
+        res_col: usize,
+        a: &VecZnxBackendRef<'_, Self>,
+        a_col: usize,
+        b: &VecZnxBackendRef<'_, Self>,
+        b_col: usize,
+        b_coeff: usize,
+        scratch: &mut ScratchArena<'_, Self>,
+    ) {
+        let mut scratch = scratch.borrow();
+        <Self as NTT4x30ConvolutionDefault<Self>>::cnv_by_const_apply_add_default(
+            module,
+            cnv_offset,
+            &mut res,
+            res_col,
+            a,
+            a_col,
+            b,
+            b_col,
+            b_coeff,
+            &mut scratch,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn cnv_apply_dft(
         module: &Module<Self>,
         cnv_offset: usize,

--- a/poulpy-cpu-avx/src/ntt4x30/module.rs
+++ b/poulpy-cpu-avx/src/ntt4x30/module.rs
@@ -42,9 +42,12 @@ pub struct NTT4x30AvxHandle {
     table_cache: ::poulpy_cpu_ref::table_cache::ModuleTableCache,
 }
 
+impl poulpy_hal::execution::ScratchWorkers for NTT4x30Avx {}
+
 impl Backend for NTT4x30Avx {
     const DFT_IS_EXACT: bool = true;
 
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type DftWord = Q120bScalar;
     type ZnxWord = i64;
     type BigWord = i128;

--- a/poulpy-cpu-avx512/src/fft64/module.rs
+++ b/poulpy-cpu-avx512/src/fft64/module.rs
@@ -81,7 +81,10 @@ pub struct FFT64Avx512Handle {
     table_cache: ::poulpy_cpu_ref::table_cache::ModuleTableCache,
 }
 
+impl poulpy_hal::execution::ScratchWorkers for FFT64Avx512 {}
+
 impl Backend for FFT64Avx512 {
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type DftWord = f64;
     type ZnxWord = i64;
     type BigWord = i64;

--- a/poulpy-cpu-avx512/src/hal_impl.rs
+++ b/poulpy-cpu-avx512/src/hal_impl.rs
@@ -290,6 +290,34 @@ unsafe impl HalConvolutionImpl<NTT4x30Avx512> for NTT4x30Avx512 {
     }
 
     #[allow(clippy::too_many_arguments)]
+    fn cnv_by_const_apply_add(
+        module: &Module<Self>,
+        cnv_offset: usize,
+        mut res: &mut poulpy_hal::layouts::VecZnxBigBackendMut<'_, Self>,
+        res_col: usize,
+        a: &VecZnxBackendRef<'_, Self>,
+        a_col: usize,
+        b: &VecZnxBackendRef<'_, Self>,
+        b_col: usize,
+        b_coeff: usize,
+        scratch: &mut ScratchArena<'_, Self>,
+    ) {
+        let mut scratch = scratch.borrow();
+        <Self as NTT4x30ConvolutionDefault<Self>>::cnv_by_const_apply_add_default(
+            module,
+            cnv_offset,
+            &mut res,
+            res_col,
+            a,
+            a_col,
+            b,
+            b_col,
+            b_coeff,
+            &mut scratch,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn cnv_apply_dft(
         module: &Module<Self>,
         cnv_offset: usize,
@@ -456,6 +484,27 @@ unsafe impl HalSvpImpl<NTT4x30Avx512> for NTT4x30Avx512 {
 }
 
 unsafe impl HalVecZnxDftImpl<NTT4x30Avx512> for NTT4x30Avx512 {
+    fn vec_znx_idft_normalize_consume_tmp_bytes(module: &Module<Self>, res_size: usize, a_size: usize) -> usize {
+        <Self as NTT4x30VecZnxDftDefault<Self>>::vec_znx_idft_normalize_consume_tmp_bytes_default(module, res_size, a_size)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn vec_znx_idft_normalize_consume(
+        module: &Module<Self>,
+        res: &mut poulpy_hal::layouts::VecZnxBackendMut<'_, Self>,
+        res_base2k: usize,
+        res_col: usize,
+        a: &mut VecZnxDftBackendMut<'_, Self>,
+        a_col: usize,
+        a_base2k: usize,
+        addend: Option<(&VecZnxBackendRef<'_, Self>, usize)>,
+        scratch: &mut ScratchArena<'_, Self>,
+    ) {
+        <Self as NTT4x30VecZnxDftDefault<Self>>::vec_znx_idft_normalize_consume_default(
+            module, res, res_base2k, res_col, a, a_col, a_base2k, addend, scratch,
+        )
+    }
+
     fn vec_znx_dft_apply(
         module: &Module<Self>,
         step: usize,
@@ -591,6 +640,19 @@ unsafe impl HalVecZnxDftImpl<NTT4x30Avx512> for NTT4x30Avx512 {
     ) {
         <Self as NTT4x30VecZnxDftDefault<Self>>::vec_znx_dft_automorphism_with_plan_default(module, plan, res, res_col, a, a_col)
     }
+
+    fn vec_znx_dft_automorphism_add_with_plan(
+        module: &Module<Self>,
+        plan: &Self::AutomorphismPlan,
+        res: &mut VecZnxDftBackendMut<'_, Self>,
+        res_col: usize,
+        a: &VecZnxDftBackendRef<'_, Self>,
+        a_col: usize,
+    ) {
+        <Self as NTT4x30VecZnxDftDefault<Self>>::vec_znx_dft_automorphism_add_with_plan_default(
+            module, plan, res, res_col, a, a_col,
+        )
+    }
 }
 
 #[cfg(feature = "enable-ifma")]
@@ -601,9 +663,10 @@ mod ifma_impl {
     use poulpy_hal::{
         api::{ScratchArenaTakeBasic, VecZnxDftApply, VecZnxDftZero, VmpApplyDftToDft},
         layouts::{
-            Backend, MatZnxBackendRef, MatZnxInfos, Module, NoiseInfos, ScalarZnxBackendRef, SvpPPolBackendMut,
-            SvpPPolBackendRef, VecZnxBackendMut, VecZnxBackendRef, VecZnxBigBackendMut, VecZnxDftBackendMut, VecZnxDftBackendRef,
-            VecZnxDftToBackendMut, VecZnxDftToBackendRef, VecZnxInfos, VmpPMatBackendMut, VmpPMatBackendRef, ZnxInfos,
+            Backend, DataView, DataViewMut, MatZnxBackendRef, MatZnxInfos, Module, NoiseInfos, ScalarZnxBackendRef,
+            SvpPPolBackendMut, SvpPPolBackendRef, VecZnxBackendMut, VecZnxBackendRef, VecZnxBigBackendMut, VecZnxDftBackendMut,
+            VecZnxDftBackendRef, VecZnxDftToBackendMut, VecZnxDftToBackendRef, VecZnxInfos, VmpPMatBackendMut, VmpPMatBackendRef,
+            ZnxInfos,
         },
         oep::{HalConvolutionImpl, HalModuleImpl, HalSvpImpl, HalVecZnxBigImpl, HalVecZnxDftImpl, HalVecZnxImpl, HalVmpImpl},
     };
@@ -808,6 +871,54 @@ mod ifma_impl {
     }
 
     unsafe impl HalVecZnxDftImpl<NTT3x42Ifma> for NTT3x42Ifma {
+        fn vec_znx_idft_normalize_consume_tmp_bytes(module: &Module<Self>, _res_size: usize, _a_size: usize) -> usize {
+            3 * module.n() * size_of::<u64>() + 3 * module.n() * size_of::<i128>()
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        fn vec_znx_idft_normalize_consume(
+            module: &Module<Self>,
+            res: &mut poulpy_hal::layouts::VecZnxBackendMut<'_, Self>,
+            res_base2k: usize,
+            res_col: usize,
+            a: &mut VecZnxDftBackendMut<'_, Self>,
+            a_col: usize,
+            a_base2k: usize,
+            addend: Option<(&poulpy_hal::layouts::VecZnxBackendRef<'_, Self>, usize)>,
+            scratch: &mut ScratchArena<'_, Self>,
+        ) {
+            let n = module.n();
+            let arena = scratch.borrow();
+            let (tmp, arena) = take_host_typed::<Self, u64>(arena, 3 * n);
+            let (carry, _) = take_host_typed::<Self, i128>(arena, 3 * n);
+            crate::ntt3x42_ifma::vec_znx_dft::idft_compact_in_place_ifma(module, a, a_col, tmp);
+            let (a_cols, a_size) = (a.cols(), a.size());
+            if let Some((add, add_col)) = addend {
+                let mut big: poulpy_hal::layouts::VecZnxBigBackendMut<'_, Self> =
+                    poulpy_hal::layouts::VecZnxBig::from_data(&mut **a.data_mut(), n, a_cols, a_size);
+                let mut big_ref = &mut big;
+                poulpy_cpu_ref::reference::ntt4x30::vec_znx_big::ntt4x30_vec_znx_big_add_small_assign::<_, _, Self>(
+                    &mut big_ref,
+                    a_col,
+                    &add,
+                    add_col,
+                );
+            }
+            let big_ref: poulpy_hal::layouts::VecZnxBigBackendRef<'_, Self> =
+                poulpy_hal::layouts::VecZnxBig::from_data(&**a.data(), n, a_cols, a_size);
+            let mut res_ref = &mut *res;
+            poulpy_cpu_ref::reference::ntt4x30::vec_znx_big::ntt4x30_vec_znx_big_normalize::<_, _, Self>(
+                &mut res_ref,
+                res_base2k,
+                0,
+                res_col,
+                &&big_ref,
+                a_base2k,
+                a_col,
+                carry,
+            );
+        }
+
         fn vec_znx_dft_apply(
             module: &Module<Self>,
             step: usize,
@@ -948,6 +1059,17 @@ mod ifma_impl {
         ) {
             crate::ntt3x42_ifma::vec_znx_dft::vec_znx_dft_automorphism(plan, res, res_col, a, a_col);
         }
+
+        fn vec_znx_dft_automorphism_add_with_plan(
+            _module: &Module<Self>,
+            plan: &Self::AutomorphismPlan,
+            res: &mut VecZnxDftBackendMut<'_, Self>,
+            res_col: usize,
+            a: &VecZnxDftBackendRef<'_, Self>,
+            a_col: usize,
+        ) {
+            crate::ntt3x42_ifma::vec_znx_dft::vec_znx_dft_automorphism_add(plan, res, res_col, a, a_col);
+        }
     }
 
     unsafe impl HalConvolutionImpl<NTT3x42Ifma> for NTT3x42Ifma {
@@ -1019,6 +1141,24 @@ mod ifma_impl {
             let bytes = crate::ntt3x42_ifma::convolution::cnv_by_const_apply_tmp_bytes(res.size(), a.size(), b.size());
             let (tmp, _) = take_host_typed::<Self, u8>(scratch.borrow(), bytes);
             crate::ntt3x42_ifma::convolution::cnv_by_const_apply(cnv_offset, res, res_col, a, a_col, b, b_col, b_coeff, tmp);
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        fn cnv_by_const_apply_add(
+            _module: &Module<Self>,
+            cnv_offset: usize,
+            res: &mut VecZnxBigBackendMut<'_, Self>,
+            res_col: usize,
+            a: &VecZnxBackendRef<'_, Self>,
+            a_col: usize,
+            b: &VecZnxBackendRef<'_, Self>,
+            b_col: usize,
+            b_coeff: usize,
+            scratch: &mut ScratchArena<'_, Self>,
+        ) {
+            let bytes = crate::ntt3x42_ifma::convolution::cnv_by_const_apply_tmp_bytes(res.size(), a.size(), b.size());
+            let (tmp, _) = take_host_typed::<Self, u8>(scratch.borrow(), bytes);
+            crate::ntt3x42_ifma::convolution::cnv_by_const_apply_add(cnv_offset, res, res_col, a, a_col, b, b_col, b_coeff, tmp);
         }
 
         #[allow(clippy::too_many_arguments)]

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/convolution.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/convolution.rs
@@ -1050,3 +1050,65 @@ pub(crate) fn cnv_by_const_apply(
         }
     });
 }
+
+/// `res[res_col] +=` the convolution-by-constant; out-of-range limbs are left
+/// untouched. This serial adapter keeps the pre-Rayon backend buildable while
+/// the shared HAL contract is introduced.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn cnv_by_const_apply_add(
+    cnv_offset: usize,
+    res: &mut VecZnxBigBackendMut<'_, NTT3x42Ifma>,
+    res_col: usize,
+    a: &VecZnxBackendRef<'_, NTT3x42Ifma>,
+    a_col: usize,
+    b: &VecZnxBackendRef<'_, NTT3x42Ifma>,
+    b_col: usize,
+    b_coeff: usize,
+    _tmp: &mut [u8],
+) {
+    let res_size = res.size();
+    let a_size = a.size();
+    let b_size = b.size();
+    if res_size == 0 || a_size == 0 || b_size == 0 {
+        return;
+    }
+
+    let bound = a_size + b_size - 1;
+    let min_size = res_size.min(bound);
+    let offset = cnv_offset.min(bound);
+    let n = res.n();
+    let rc = res.cols();
+    let res_raw = res.raw_mut();
+
+    if b_size == 1 {
+        let b0 = b.at(b_col, 0)[b_coeff] as i128;
+        for_index(min_size, 2 * n * min_size, |k| {
+            let k_abs = k + offset;
+            if k_abs < a_size {
+                let start = n * (k * rc + res_col);
+                let res_limb = &mut res_raw[start..start + n];
+                let a_limb = a.at(a_col, k_abs);
+                for n_i in 0..res_limb.len() {
+                    res_limb[n_i] += (a_limb[n_i] as i128) * b0;
+                }
+            }
+        });
+        return;
+    }
+
+    for_index(min_size, 2 * n * min_size * b_size, |k| {
+        let start = n * (k * rc + res_col);
+        let res_limb = &mut res_raw[start..start + n];
+        let k_abs = k + offset;
+        let j_min = k_abs.saturating_sub(a_size - 1);
+        let j_max = (k_abs + 1).min(b_size);
+        for (n_i, r) in res_limb.iter_mut().enumerate() {
+            let mut acc = 0i128;
+            for j in j_min..j_max {
+                let b_j = b.at(b_col, j)[b_coeff];
+                acc += a.at(a_col, k_abs - j)[n_i] as i128 * b_j as i128;
+            }
+            *r += acc;
+        }
+    });
+}

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/module.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/module.rs
@@ -39,6 +39,7 @@ pub struct NTT3x42IfmaHandle {
 impl Backend for NTT3x42Ifma {
     const DFT_IS_EXACT: bool = true;
 
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type DftWord = Q126Scalar;
     type ZnxWord = i64;
     type BigWord = i128;

--- a/poulpy-cpu-avx512/src/ntt3x42_ifma/vec_znx_dft.rs
+++ b/poulpy-cpu-avx512/src/ntt3x42_ifma/vec_znx_dft.rs
@@ -531,6 +531,30 @@ pub(crate) fn vec_znx_idft_apply_tmpa_ifma(
     );
 }
 
+/// In-place iNTT of `a[a_col]`'s limbs for the serial compatibility path.
+/// Each packed limb is replaced by its `i128` compaction, leaving that column
+/// in `VecZnxBig` layout.
+pub(crate) fn idft_compact_in_place_ifma(
+    module: &Module<NTT3x42Ifma>,
+    a: &mut VecZnxDftBackendMut<'_, NTT3x42Ifma>,
+    a_col: usize,
+    tmp: &mut [u64],
+) {
+    let table = &handle(module).table_intt;
+    let n = a.n();
+    assert!(tmp.len() >= 3 * n);
+    let a_cols = a.cols();
+    let a_size = a.size();
+    let data: &mut [u64] = cast_slice_mut(a.data_mut());
+    for j in 0..a_size {
+        let slot = packed_limb_mut(data, n, a_cols, a_col, j);
+        unsafe {
+            unpack_limb_3x42(n, tmp, slot);
+            intt_then_compact_ifma(n, 1, tmp.as_mut_ptr(), slot.as_mut_ptr() as *mut i128, table);
+        }
+    }
+}
+
 /// Forward NTT into the packed layout.
 pub(crate) fn vec_znx_dft_apply(
     module: &Module<NTT3x42Ifma>,
@@ -837,6 +861,61 @@ pub(crate) fn vec_znx_dft_zero(res: &mut VecZnxDftBackendMut<'_, NTT3x42Ifma>, r
         let dst = packed_limb_mut(rp, n, rc, res_col, j);
         dst.fill(0);
     });
+}
+
+/// Packed-layout NTT3x42 automorphism fused with serial accumulation.
+pub(crate) fn vec_znx_dft_automorphism_add(
+    plan: &poulpy_cpu_ref::reference::ntt4x30::vec_znx_dft::NttAutomorphismPlan,
+    res: &mut VecZnxDftBackendMut<'_, NTT3x42Ifma>,
+    res_col: usize,
+    a: &VecZnxDftBackendRef<'_, NTT3x42Ifma>,
+    a_col: usize,
+) {
+    #[cfg(debug_assertions)]
+    {
+        assert_eq!(a.n(), res.n());
+        assert_eq!(plan.perm.len(), res.n());
+    }
+
+    let n = res.n();
+    let (rc, ac) = (res.cols(), a.cols());
+    let min_size = res.size().min(a.size());
+    let perm = &plan.perm;
+    let rp: &mut [u64] = cast_slice_mut(res.data_mut());
+    let ap: &[u64] = cast_slice(a.data());
+    for_index(min_size, 2 * n * min_size, |limb| {
+        let dst = packed_limb_mut(rp, n, rc, res_col, limb);
+        let src = packed_limb(ap, n, ac, a_col, limb);
+        unsafe { automorphism_add_limb(n, perm, dst, src) };
+    });
+}
+
+#[target_feature(enable = "avx512f")]
+unsafe fn automorphism_add_limb(n: usize, perm: &[u32], dst: &mut [u64], a: &[u64]) {
+    unsafe {
+        let m42 = _mm512_set1_epi64(MASK42 as i64);
+        let m20 = _mm512_set1_epi64(MASK20 as i64);
+        let m22 = _mm512_set1_epi64(MASK22 as i64);
+        let q = q_vec_512();
+        let mut buf = [0u64; 16];
+        for g in 0..n / 8 {
+            for (lane, &p) in perm[8 * g..8 * g + 8].iter().enumerate() {
+                let p = p as usize;
+                let src_off = 16 * (p >> 3) + (p & 7);
+                buf[lane] = a[src_off];
+                buf[lane + 8] = a[src_off + 8];
+            }
+            let off = 16 * g;
+            let ya = load_group(&buf, 0, m42, m20);
+            let yd = load_group(dst, off, m42, m20);
+            let sum = [
+                cond_sub_2q_si512(_mm512_add_epi64(yd[0], ya[0]), q[0]),
+                cond_sub_2q_si512(_mm512_add_epi64(yd[1], ya[1]), q[1]),
+                cond_sub_2q_si512(_mm512_add_epi64(yd[2], ya[2]), q[2]),
+            ];
+            store_group(dst, off, sum, m22);
+        }
+    }
 }
 
 /// Packed-layout NTT3x42 automorphism.

--- a/poulpy-cpu-avx512/src/ntt4x30_avx512/module.rs
+++ b/poulpy-cpu-avx512/src/ntt4x30_avx512/module.rs
@@ -39,9 +39,12 @@ pub struct NTT4x30Avx512Handle {
     table_cache: ::poulpy_cpu_ref::table_cache::ModuleTableCache,
 }
 
+impl poulpy_hal::execution::ScratchWorkers for NTT4x30Avx512 {}
+
 impl Backend for NTT4x30Avx512 {
     const DFT_IS_EXACT: bool = true;
 
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type DftWord = Q120bScalar;
     type ZnxWord = i64;
     type BigWord = i128;

--- a/poulpy-cpu-ref/src/fft64/module.rs
+++ b/poulpy-cpu-ref/src/fft64/module.rs
@@ -37,7 +37,10 @@ pub struct FFT64RefHandle {
     table_cache: crate::table_cache::ModuleTableCache,
 }
 
+impl poulpy_hal::execution::ScratchWorkers for FFT64Ref {}
+
 impl Backend for FFT64Ref {
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type DftWord = f64;
     type ZnxWord = i64;
     type BigWord = i64;

--- a/poulpy-cpu-ref/src/hal_defaults/convolution.rs
+++ b/poulpy-cpu-ref/src/hal_defaults/convolution.rs
@@ -6,9 +6,9 @@ use crate::reference::{
     fft64::{
         convolution::{
             I64Ops, convolution_apply_dft, convolution_apply_dft_accumulate, convolution_apply_dft_tmp_bytes,
-            convolution_by_const_apply, convolution_by_const_apply_tmp_bytes, convolution_pairwise_apply_dft,
-            convolution_pairwise_apply_dft_tmp_bytes, convolution_prepare_left, convolution_prepare_right,
-            convolution_prepare_self,
+            convolution_by_const_apply, convolution_by_const_apply_add, convolution_by_const_apply_tmp_bytes,
+            convolution_pairwise_apply_dft, convolution_pairwise_apply_dft_tmp_bytes, convolution_prepare_left,
+            convolution_prepare_right, convolution_prepare_self,
         },
         module::FFTModuleHandle,
         reim::{ReimArith, ReimFFTExecute, ReimFFTTable},
@@ -17,11 +17,12 @@ use crate::reference::{
     ntt4x30::{
         NttAddAssign, NttCFromB, NttDFTExecute, NttFromZnx64, NttMulBbc1ColX2, NttPackLeft1BlkX2,
         convolution::{
-            ntt4x30_cnv_accumulate_dft, ntt4x30_cnv_accumulate_dft_tmp_bytes, ntt4x30_cnv_apply_dft,
+            CNV_ACC_GROUP, ntt4x30_cnv_accumulate_dft, ntt4x30_cnv_accumulate_dft_tmp_bytes, ntt4x30_cnv_apply_dft,
             ntt4x30_cnv_apply_dft_accumulate, ntt4x30_cnv_apply_dft_tmp_bytes, ntt4x30_cnv_by_const_apply,
-            ntt4x30_cnv_by_const_apply_tmp_bytes, ntt4x30_cnv_pairwise_apply_dft, ntt4x30_cnv_pairwise_apply_dft_tmp_bytes,
-            ntt4x30_cnv_prepare_left, ntt4x30_cnv_prepare_left_tmp_bytes, ntt4x30_cnv_prepare_right,
-            ntt4x30_cnv_prepare_right_tmp_bytes, ntt4x30_cnv_prepare_self, ntt4x30_cnv_prepare_self_tmp_bytes,
+            ntt4x30_cnv_by_const_apply_add, ntt4x30_cnv_by_const_apply_tmp_bytes, ntt4x30_cnv_pairwise_apply_dft,
+            ntt4x30_cnv_pairwise_apply_dft_tmp_bytes, ntt4x30_cnv_prepare_left, ntt4x30_cnv_prepare_left_tmp_bytes,
+            ntt4x30_cnv_prepare_right, ntt4x30_cnv_prepare_right_tmp_bytes, ntt4x30_cnv_prepare_self,
+            ntt4x30_cnv_prepare_self_tmp_bytes,
         },
         ntt::NttTable,
         primes::Primes30,
@@ -31,6 +32,7 @@ use crate::reference::{
 };
 use poulpy_hal::{
     api::{HostBufMut, ModuleN, VecZnxDftBytesOf},
+    execution::{ScratchWorkers, SerialTaskExecutor, scratch_workers, scratch_workers_within},
     layouts::{
         Backend, CnvPVecLBackendMut, CnvPVecLBackendRef, CnvPVecRBackendMut, CnvPVecRBackendRef, HostDataRef, Module,
         ScratchArena, VecZnxBackendRef, VecZnxBigToBackendMut, VecZnxDft, VecZnxDftToBackendMut,
@@ -65,7 +67,7 @@ where
     (slice, arena)
 }
 #[doc(hidden)]
-pub trait FFT64ConvolutionDefault<BE: Backend<ZnxWord = i64>>: Backend
+pub trait FFT64ConvolutionDefault<BE: Backend<ZnxWord = i64> + ScratchWorkers>: Backend
 where
     BE::OwnedBuf: poulpy_hal::layouts::HostDataMut,
 {
@@ -131,7 +133,7 @@ where
     where
         BE: Backend<DftWord = f64, ZnxWord = i64>,
     {
-        convolution_apply_dft_tmp_bytes(res_size, a_size, b_size)
+        reim4_block_workers::<BE>(_module) * convolution_apply_dft_tmp_bytes(res_size, a_size, b_size)
     }
 
     fn cnv_by_const_apply_tmp_bytes_default(
@@ -173,6 +175,31 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
+    fn cnv_by_const_apply_add_default<R>(
+        _module: &Module<BE>,
+        cnv_offset: usize,
+        res: &mut R,
+        res_col: usize,
+        a: &VecZnxBackendRef<'_, BE>,
+        a_col: usize,
+        b: &VecZnxBackendRef<'_, BE>,
+        b_col: usize,
+        b_coeff: usize,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) where
+        BE: Backend<BigWord = i64, ZnxWord = i64> + I64Ops + 'static,
+        for<'x> BE: Backend<BufRef<'x> = &'x [u8], ZnxWord = i64>,
+        for<'x> <BE as Backend>::BufMut<'x>: poulpy_hal::layouts::HostDataMut,
+        for<'x> BE::BufMut<'x>: HostBufMut<'x>,
+        R: VecZnxBigToBackendMut<BE>,
+    {
+        let mut res_ref = res.to_backend_mut();
+        let bytes = convolution_by_const_apply_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let (tmp, _) = take_host_typed::<BE, i64>(scratch.borrow(), bytes / size_of::<i64>());
+        convolution_by_const_apply_add::<BE>(cnv_offset, &mut res_ref, res_col, a, a_col, b, b_col, b_coeff, tmp);
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn cnv_apply_dft_default<R>(
         _module: &Module<BE>,
         cnv_offset: usize,
@@ -191,7 +218,8 @@ where
         R: VecZnxDftToBackendMut<BE>,
     {
         let mut res_ref = res.to_backend_mut();
-        let bytes = convolution_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let per_worker = convolution_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let bytes = reim4_block_workers_within::<BE>(_module, per_worker, scratch.available()) * per_worker;
         let (tmp, _) = take_host_typed::<BE, f64>(scratch.borrow(), bytes / size_of::<f64>());
         convolution_apply_dft::<BE>(cnv_offset, &mut res_ref, res_col, a, a_col, b, b_col, tmp);
     }
@@ -215,7 +243,8 @@ where
         R: VecZnxDftToBackendMut<BE>,
     {
         let mut res_ref = res.to_backend_mut();
-        let bytes = convolution_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let per_worker = convolution_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let bytes = reim4_block_workers_within::<BE>(_module, per_worker, scratch.available()) * per_worker;
         let (tmp, _) = take_host_typed::<BE, f64>(scratch.borrow(), bytes / size_of::<f64>());
         convolution_apply_dft_accumulate::<BE>(cnv_offset, &mut res_ref, res_col, a, a_col, b, b_col, tmp);
     }
@@ -230,7 +259,7 @@ where
     where
         BE: Backend<DftWord = f64, ZnxWord = i64>,
     {
-        convolution_pairwise_apply_dft_tmp_bytes(res_size, a_size, b_size)
+        reim4_block_workers::<BE>(_module) * convolution_pairwise_apply_dft_tmp_bytes(res_size, a_size, b_size)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -252,7 +281,8 @@ where
         R: VecZnxDftToBackendMut<BE>,
     {
         let mut res_ref = res.to_backend_mut();
-        let bytes = convolution_pairwise_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let per_worker = convolution_pairwise_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let bytes = reim4_block_workers_within::<BE>(_module, per_worker, scratch.available()) * per_worker;
         let (tmp, _) = take_host_typed::<BE, f64>(scratch.borrow(), bytes / size_of::<f64>());
         convolution_pairwise_apply_dft::<BE>(cnv_offset, &mut res_ref, res_col, a, b, i, j, tmp);
     }
@@ -285,18 +315,58 @@ where
     }
 }
 
-impl<BE: Backend<ZnxWord = i64>> FFT64ConvolutionDefault<BE> for BE where BE::OwnedBuf: poulpy_hal::layouts::HostDataMut {}
+impl<BE: Backend<ZnxWord = i64> + ScratchWorkers> FFT64ConvolutionDefault<BE> for BE where
+    BE::OwnedBuf: poulpy_hal::layouts::HostDataMut
+{
+}
+
+/// Worker slices for the block-parallel reim4 convolution kernels.
+fn reim4_block_workers<BE: Backend + ScratchWorkers>(module: &Module<BE>) -> usize
+where
+    Module<BE>: ModuleN,
+{
+    scratch_workers::<BE::TaskExecutor>((module.n() / 8).min(BE::APPLY))
+}
+
+fn reim4_block_workers_within<BE: Backend + ScratchWorkers>(module: &Module<BE>, per_worker: usize, available: usize) -> usize
+where
+    Module<BE>: ModuleN,
+{
+    scratch_workers_within::<BE::TaskExecutor>((module.n() / 8).min(BE::APPLY), per_worker, available)
+}
+
+/// Worker slices for the block-group parallel convolution kernels.
+fn cnv_group_workers<BE: Backend + ScratchWorkers>(module: &Module<BE>) -> usize
+where
+    Module<BE>: ModuleN,
+{
+    scratch_workers::<BE::TaskExecutor>(cnv_groups(module).min(BE::APPLY))
+}
+
+fn cnv_group_workers_within<BE: Backend + ScratchWorkers>(module: &Module<BE>, per_worker: usize, available: usize) -> usize
+where
+    Module<BE>: ModuleN,
+{
+    scratch_workers_within::<BE::TaskExecutor>(cnv_groups(module).min(BE::APPLY), per_worker, available)
+}
+
+fn cnv_groups<BE: Backend>(module: &Module<BE>) -> usize
+where
+    Module<BE>: ModuleN,
+{
+    (module.n() / 2).div_ceil(CNV_ACC_GROUP)
+}
 
 #[doc(hidden)]
-pub trait NTT4x30ConvolutionDefault<BE: Backend<ZnxWord = i64>>: Backend
+pub trait NTT4x30ConvolutionDefault<BE: Backend<ZnxWord = i64> + ScratchWorkers>: Backend
 where
     BE::OwnedBuf: poulpy_hal::layouts::HostDataMut,
 {
-    fn cnv_prepare_left_tmp_bytes_default(module: &Module<BE>, _res_size: usize, _a_size: usize) -> usize
+    fn cnv_prepare_left_tmp_bytes_default(module: &Module<BE>, res_size: usize, _a_size: usize) -> usize
     where
         BE: Backend<DftWord = Q120bScalar, ZnxWord = i64>,
     {
-        ntt4x30_cnv_prepare_left_tmp_bytes(module.n())
+        scratch_workers::<BE::TaskExecutor>(res_size.min(BE::PREPARE)) * ntt4x30_cnv_prepare_left_tmp_bytes(module.n())
     }
 
     fn cnv_prepare_left_default(
@@ -315,16 +385,18 @@ where
         for<'x> BE: Backend<BufRef<'x> = &'x [u8], BufMut<'x> = &'x mut [u8], ZnxWord = i64>,
         for<'x> BE::BufMut<'x>: HostBufMut<'x>,
     {
-        let bytes = ntt4x30_cnv_prepare_left_tmp_bytes(module.n());
+        let per_worker = ntt4x30_cnv_prepare_left_tmp_bytes(module.n());
+        let bytes =
+            scratch_workers_within::<BE::TaskExecutor>(res.size().min(BE::PREPARE), per_worker, scratch.available()) * per_worker;
         let (tmp, _) = take_host_typed::<BE, u8>(scratch.borrow(), bytes);
         ntt4x30_cnv_prepare_left::<BE>(module, res, a, mask, tmp);
     }
 
-    fn cnv_prepare_right_tmp_bytes_default(module: &Module<BE>, _res_size: usize, _a_size: usize) -> usize
+    fn cnv_prepare_right_tmp_bytes_default(module: &Module<BE>, res_size: usize, _a_size: usize) -> usize
     where
         BE: Backend<DftWord = Q120bScalar, ZnxWord = i64>,
     {
-        ntt4x30_cnv_prepare_right_tmp_bytes(module.n())
+        scratch_workers::<BE::TaskExecutor>(res_size.min(BE::PREPARE)) * ntt4x30_cnv_prepare_right_tmp_bytes(module.n())
     }
 
     fn cnv_prepare_right_default(
@@ -343,7 +415,9 @@ where
         for<'x> BE: Backend<BufRef<'x> = &'x [u8], BufMut<'x> = &'x mut [u8], ZnxWord = i64>,
         for<'x> BE::BufMut<'x>: HostBufMut<'x>,
     {
-        let bytes = ntt4x30_cnv_prepare_right_tmp_bytes(module.n());
+        let per_worker = ntt4x30_cnv_prepare_right_tmp_bytes(module.n());
+        let bytes =
+            scratch_workers_within::<BE::TaskExecutor>(res.size().min(BE::PREPARE), per_worker, scratch.available()) * per_worker;
         let (tmp, _) = take_host_typed::<BE, u64>(scratch.borrow(), bytes / size_of::<u64>());
         ntt4x30_cnv_prepare_right::<BE>(module, res, a, mask, tmp);
     }
@@ -358,7 +432,7 @@ where
     where
         BE: Backend<DftWord = Q120bScalar, ZnxWord = i64>,
     {
-        ntt4x30_cnv_apply_dft_tmp_bytes(res_size, a_size, b_size)
+        cnv_group_workers::<BE>(_module) * ntt4x30_cnv_apply_dft_tmp_bytes(res_size, a_size, b_size)
     }
 
     fn cnv_by_const_apply_tmp_bytes_default(
@@ -396,7 +470,42 @@ where
         let mut res_ref = res.to_backend_mut();
         let bytes = ntt4x30_cnv_by_const_apply_tmp_bytes(0, 0, 0);
         let (tmp, _) = take_host_typed::<BE, u8>(scratch.borrow(), bytes);
-        ntt4x30_cnv_by_const_apply::<BE>(cnv_offset, &mut res_ref, res_col, a, a_col, b, b_col, b_coeff, tmp);
+        ntt4x30_cnv_by_const_apply::<BE, SerialTaskExecutor>(cnv_offset, &mut res_ref, res_col, a, a_col, b, b_col, b_coeff, tmp);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn cnv_by_const_apply_add_default<R>(
+        _module: &Module<BE>,
+        cnv_offset: usize,
+        res: &mut R,
+        res_col: usize,
+        a: &VecZnxBackendRef<'_, BE>,
+        a_col: usize,
+        b: &VecZnxBackendRef<'_, BE>,
+        b_col: usize,
+        b_coeff: usize,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) where
+        BE: Backend<BigWord = i128, DftWord = Q120bScalar, ZnxWord = i64> + 'static,
+        for<'x> BE: Backend<BufRef<'x> = &'x [u8], ZnxWord = i64>,
+        for<'x> <BE as Backend>::BufMut<'x>: poulpy_hal::layouts::HostDataMut,
+        for<'x> BE::BufMut<'x>: HostBufMut<'x>,
+        R: VecZnxBigToBackendMut<BE>,
+    {
+        let mut res_ref = res.to_backend_mut();
+        let bytes = ntt4x30_cnv_by_const_apply_tmp_bytes(0, 0, 0);
+        let (tmp, _) = take_host_typed::<BE, u8>(scratch.borrow(), bytes);
+        ntt4x30_cnv_by_const_apply_add::<BE, SerialTaskExecutor>(
+            cnv_offset,
+            &mut res_ref,
+            res_col,
+            a,
+            a_col,
+            b,
+            b_col,
+            b_coeff,
+            tmp,
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -419,7 +528,8 @@ where
         R: VecZnxDftToBackendMut<BE>,
     {
         let mut res_ref = res.to_backend_mut();
-        let bytes = ntt4x30_cnv_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let per_worker = ntt4x30_cnv_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let bytes = cnv_group_workers_within::<BE>(module, per_worker, scratch.available()) * per_worker;
         let (tmp, _) = take_host_typed::<BE, u8>(scratch.borrow(), bytes);
         ntt4x30_cnv_apply_dft::<BE>(module, cnv_offset, &mut res_ref, res_col, a, a_col, b, b_col, tmp);
     }
@@ -444,7 +554,8 @@ where
         R: VecZnxDftToBackendMut<BE>,
     {
         let mut res_ref = res.to_backend_mut();
-        let bytes = ntt4x30_cnv_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let per_worker = ntt4x30_cnv_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let bytes = cnv_group_workers_within::<BE>(module, per_worker, scratch.available()) * per_worker;
         let (tmp, _) = take_host_typed::<BE, u8>(scratch.borrow(), bytes);
         ntt4x30_cnv_apply_dft_accumulate::<BE>(module, cnv_offset, &mut res_ref, res_col, a, a_col, b, b_col, tmp);
     }
@@ -493,7 +604,7 @@ where
     where
         BE: Backend<DftWord = Q120bScalar, ZnxWord = i64>,
     {
-        ntt4x30_cnv_pairwise_apply_dft_tmp_bytes(res_size, a_size, b_size)
+        cnv_group_workers::<BE>(_module) * ntt4x30_cnv_pairwise_apply_dft_tmp_bytes(res_size, a_size, b_size)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -516,16 +627,17 @@ where
         R: VecZnxDftToBackendMut<BE>,
     {
         let mut res_ref = res.to_backend_mut();
-        let bytes = ntt4x30_cnv_pairwise_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let per_worker = ntt4x30_cnv_pairwise_apply_dft_tmp_bytes(res_ref.size(), a.size(), b.size());
+        let bytes = cnv_group_workers_within::<BE>(module, per_worker, scratch.available()) * per_worker;
         let (tmp, _) = take_host_typed::<BE, u8>(scratch.borrow(), bytes);
         ntt4x30_cnv_pairwise_apply_dft::<BE>(module, cnv_offset, &mut res_ref, res_col, a, b, i, j, tmp);
     }
 
-    fn cnv_prepare_self_tmp_bytes_default(module: &Module<BE>, _res_size: usize, _a_size: usize) -> usize
+    fn cnv_prepare_self_tmp_bytes_default(module: &Module<BE>, res_size: usize, _a_size: usize) -> usize
     where
         BE: Backend<DftWord = Q120bScalar, ZnxWord = i64>,
     {
-        ntt4x30_cnv_prepare_self_tmp_bytes(module.n())
+        scratch_workers::<BE::TaskExecutor>(res_size.min(BE::PREPARE)) * ntt4x30_cnv_prepare_self_tmp_bytes(module.n())
     }
 
     fn cnv_prepare_self_default(
@@ -546,10 +658,15 @@ where
         for<'x> BE: Backend<BufRef<'x> = &'x [u8], BufMut<'x> = &'x mut [u8], ZnxWord = i64>,
         for<'x> BE::BufMut<'x>: HostBufMut<'x>,
     {
-        let bytes = ntt4x30_cnv_prepare_self_tmp_bytes(module.n());
+        let per_worker = ntt4x30_cnv_prepare_self_tmp_bytes(module.n());
+        let bytes = scratch_workers_within::<BE::TaskExecutor>(left.size().min(BE::PREPARE), per_worker, scratch.available())
+            * per_worker;
         let (tmp, _) = take_host_typed::<BE, u8>(scratch.borrow(), bytes);
         ntt4x30_cnv_prepare_self::<BE>(module, left, right, a, mask, tmp);
     }
 }
 
-impl<BE: Backend<ZnxWord = i64>> NTT4x30ConvolutionDefault<BE> for BE where BE::OwnedBuf: poulpy_hal::layouts::HostDataMut {}
+impl<BE: Backend<ZnxWord = i64> + ScratchWorkers> NTT4x30ConvolutionDefault<BE> for BE where
+    BE::OwnedBuf: poulpy_hal::layouts::HostDataMut
+{
+}

--- a/poulpy-cpu-ref/src/hal_defaults/vec_znx_dft.rs
+++ b/poulpy-cpu-ref/src/hal_defaults/vec_znx_dft.rs
@@ -6,11 +6,16 @@ use crate::reference::{
     fft64::{
         module::FFTModuleHandle,
         reim::{ReimArith, ReimFFTExecute, ReimFFTTable, ReimIFFTTable},
+        vec_znx_big::{
+            vec_znx_big_add_small_assign as fft64_vec_znx_big_add_small_assign,
+            vec_znx_big_normalize as fft64_default_vec_znx_big_normalize,
+        },
         vec_znx_dft::{
             Fft64AutomorphismPlan, build_fft64_automorphism_plan, vec_znx_dft_add_assign as fft64_vec_znx_dft_add_assign,
             vec_znx_dft_add_into as fft64_vec_znx_dft_add_into,
             vec_znx_dft_add_scaled_assign as fft64_vec_znx_dft_add_scaled_assign, vec_znx_dft_apply as fft64_vec_znx_dft_apply,
-            vec_znx_dft_automorphism as fft64_vec_znx_dft_automorphism, vec_znx_dft_copy as fft64_vec_znx_dft_copy,
+            vec_znx_dft_automorphism as fft64_vec_znx_dft_automorphism,
+            vec_znx_dft_automorphism_add as fft64_vec_znx_dft_automorphism_add, vec_znx_dft_copy as fft64_vec_znx_dft_copy,
             vec_znx_dft_sub as fft64_vec_znx_dft_sub, vec_znx_dft_sub_assign as fft64_vec_znx_dft_sub_assign,
             vec_znx_dft_sub_negate_assign as fft64_vec_znx_dft_sub_negate_assign, vec_znx_dft_zero as fft64_vec_znx_dft_zero,
             vec_znx_idft_apply as fft64_vec_znx_idft_apply, vec_znx_idft_apply_tmpa as fft64_vec_znx_idft_apply_tmpa,
@@ -22,6 +27,10 @@ use crate::reference::{
         ntt::{NttTable, NttTableInv},
         primes::Primes30,
         types::Q120bScalar,
+        vec_znx_big::{
+            I128BigOps, I128NormalizeOps, ntt4x30_vec_znx_big_add_small_assign,
+            ntt4x30_vec_znx_big_normalize as ntt4x30_default_vec_znx_big_normalize,
+        },
         vec_znx_dft::{
             NttAutomorphismPlan, NttModuleHandle, build_ntt4x30_automorphism_plan,
             ntt4x30_vec_znx_dft_add_assign as ntt4x30_default_vec_znx_dft_add_assign,
@@ -29,6 +38,7 @@ use crate::reference::{
             ntt4x30_vec_znx_dft_add_scaled_assign as ntt4x30_default_vec_znx_dft_add_scaled_assign,
             ntt4x30_vec_znx_dft_apply as ntt4x30_default_vec_znx_dft_apply,
             ntt4x30_vec_znx_dft_automorphism as ntt4x30_default_vec_znx_dft_automorphism,
+            ntt4x30_vec_znx_dft_automorphism_add as ntt4x30_default_vec_znx_dft_automorphism_add,
             ntt4x30_vec_znx_dft_copy as ntt4x30_default_vec_znx_dft_copy,
             ntt4x30_vec_znx_dft_sub as ntt4x30_default_vec_znx_dft_sub,
             ntt4x30_vec_znx_dft_sub_assign as ntt4x30_default_vec_znx_dft_sub_assign,
@@ -39,13 +49,17 @@ use crate::reference::{
             ntt4x30_vec_znx_idft_apply_tmpa as ntt4x30_default_vec_znx_idft_apply_tmpa,
         },
     },
-    znx::ZnxZero,
+    znx::{
+        ZnxAddAssign, ZnxCopy, ZnxExtractDigitAddMul, ZnxMulPowerOfTwoAssign, ZnxNormalizeDigit, ZnxNormalizeFinalStep,
+        ZnxNormalizeFinalStepAssign, ZnxNormalizeFirstStep, ZnxNormalizeFirstStepCarryOnly, ZnxNormalizeMiddleStep,
+        ZnxNormalizeMiddleStepAssign, ZnxNormalizeMiddleStepCarryOnly, ZnxZero,
+    },
 };
 use poulpy_hal::{
     api::HostBufMut,
     layouts::{
-        Backend, HostDataMut, HostDataRef, Module, ScratchArena, VecZnxBackendRef, VecZnxBigBackendMut, VecZnxDftBackendMut,
-        VecZnxDftBackendRef,
+        Backend, HostDataMut, HostDataRef, Module, ScratchArena, VecZnxBackendMut, VecZnxBackendRef, VecZnxBig,
+        VecZnxBigBackendMut, VecZnxDftBackendMut, VecZnxDftBackendRef,
     },
 };
 
@@ -135,6 +149,63 @@ where
         for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
     {
         fft64_vec_znx_idft_apply_tmpa::<BE>(module.get_ifft_table(), res, res_col, a, a_col);
+    }
+    fn vec_znx_idft_normalize_consume_tmp_bytes_default(module: &Module<BE>, _res_size: usize, a_size: usize) -> usize
+    where
+        BE: Backend<DftWord = f64, BigWord = i64, ZnxWord = i64>,
+    {
+        BE::bytes_of_vec_znx_big(module.n(), 1, a_size) + 3 * module.n() * size_of::<i64>()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn vec_znx_idft_normalize_consume_default(
+        module: &Module<BE>,
+        res: &mut VecZnxBackendMut<'_, BE>,
+        res_base2k: usize,
+        res_col: usize,
+        a: &mut VecZnxDftBackendMut<'_, BE>,
+        a_col: usize,
+        a_base2k: usize,
+        addend: Option<(&VecZnxBackendRef<'_, BE>, usize)>,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) where
+        Module<BE>: FFTModuleHandle<f64>,
+        BE: Backend<DftWord = f64, BigWord = i64, ZnxWord = i64>
+            + ReimArith
+            + ReimFFTExecute<ReimIFFTTable<f64>, f64>
+            + ZnxZero
+            + ZnxCopy
+            + ZnxAddAssign
+            + ZnxMulPowerOfTwoAssign
+            + ZnxNormalizeFirstStepCarryOnly
+            + ZnxNormalizeMiddleStepCarryOnly
+            + ZnxNormalizeMiddleStep
+            + ZnxNormalizeFinalStep
+            + ZnxNormalizeFirstStep
+            + ZnxExtractDigitAddMul
+            + ZnxNormalizeMiddleStepAssign
+            + ZnxNormalizeFinalStepAssign
+            + ZnxNormalizeDigit,
+        for<'x> BE: Backend<BufRef<'x> = &'x [u8], BufMut<'x> = &'x mut [u8]>,
+        for<'x> BE::BufMut<'x>: HostBufMut<'x>,
+        BE: 'static,
+    {
+        let n = module.n();
+        let a_size = a.size();
+        let arena = scratch.borrow();
+        let (big_bytes, arena) = take_host_typed::<BE, u8>(arena, BE::bytes_of_vec_znx_big(n, 1, a_size));
+        let (carry, _) = take_host_typed::<BE, i64>(arena, 3 * n);
+        {
+            let mut big: VecZnxBigBackendMut<'_, BE> = VecZnxBig::from_data(&mut *big_bytes, n, 1, a_size);
+            fft64_vec_znx_idft_apply_tmpa::<BE>(module.get_ifft_table(), &mut big, 0, a, a_col);
+            if let Some((add, add_col)) = addend {
+                let mut big_ref: &mut VecZnxBigBackendMut<'_, BE> = &mut big;
+                fft64_vec_znx_big_add_small_assign::<_, _, BE>(&mut big_ref, 0, &add, add_col);
+            }
+        }
+        let big_ref: poulpy_hal::layouts::VecZnxBigBackendRef<'_, BE> = VecZnxBig::from_data(&*big_bytes, n, 1, a_size);
+        let mut res_ref: &mut VecZnxBackendMut<'_, BE> = res;
+        fft64_default_vec_znx_big_normalize::<_, _, BE>(&mut res_ref, res_base2k, 0, res_col, &&big_ref, a_base2k, 0, carry);
     }
 
     fn vec_znx_dft_add_into_default(
@@ -271,6 +342,21 @@ where
     {
         fft64_vec_znx_dft_automorphism::<BE>(plan, res, res_col, a, a_col);
     }
+
+    fn vec_znx_dft_automorphism_add_with_plan_default(
+        _module: &Module<BE>,
+        plan: &Fft64AutomorphismPlan,
+        res: &mut VecZnxDftBackendMut<'_, BE>,
+        res_col: usize,
+        a: &VecZnxDftBackendRef<'_, BE>,
+        a_col: usize,
+    ) where
+        BE: Backend<DftWord = f64, ZnxWord = i64>,
+        for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
+        for<'x> <BE as Backend>::BufRef<'x>: HostDataRef,
+    {
+        fft64_vec_znx_dft_automorphism_add::<BE, poulpy_hal::execution::SerialTaskExecutor>(plan, res, res_col, a, a_col);
+    }
 }
 
 impl<BE: Backend<ZnxWord = i64>> FFT64VecZnxDftDefault<BE> for BE
@@ -349,6 +435,52 @@ where
         for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
     {
         ntt4x30_default_vec_znx_idft_apply_tmpa::<BE>(module, res, res_col, a, a_col);
+    }
+    fn vec_znx_idft_normalize_consume_tmp_bytes_default(module: &Module<BE>, _res_size: usize, a_size: usize) -> usize
+    where
+        BE: Backend<DftWord = Q120bScalar, BigWord = i128, ZnxWord = i64>,
+    {
+        BE::bytes_of_vec_znx_big(module.n(), 1, a_size) + 3 * module.n() * size_of::<i128>()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn vec_znx_idft_normalize_consume_default(
+        module: &Module<BE>,
+        res: &mut VecZnxBackendMut<'_, BE>,
+        res_base2k: usize,
+        res_col: usize,
+        a: &mut VecZnxDftBackendMut<'_, BE>,
+        a_col: usize,
+        a_base2k: usize,
+        addend: Option<(&VecZnxBackendRef<'_, BE>, usize)>,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) where
+        Module<BE>: NttModuleHandle,
+        BE: Backend<DftWord = Q120bScalar, BigWord = i128, ZnxWord = i64>
+            + NttDFTExecute<NttTableInv<Primes30>>
+            + NttToZnx128
+            + I128BigOps
+            + I128NormalizeOps,
+        for<'x> BE: Backend<BufRef<'x> = &'x [u8], BufMut<'x> = &'x mut [u8]>,
+        for<'x> BE::BufMut<'x>: HostBufMut<'x>,
+        BE: 'static,
+    {
+        let n = module.n();
+        let a_size = a.size();
+        let arena = scratch.borrow();
+        let (big_bytes, arena) = take_host_typed::<BE, u8>(arena, BE::bytes_of_vec_znx_big(n, 1, a_size));
+        let (carry, _) = take_host_typed::<BE, i128>(arena, 3 * n);
+        {
+            let mut big: VecZnxBigBackendMut<'_, BE> = VecZnxBig::from_data(&mut *big_bytes, n, 1, a_size);
+            ntt4x30_default_vec_znx_idft_apply_tmpa::<BE>(module, &mut big, 0, a, a_col);
+            if let Some((add, add_col)) = addend {
+                let mut big_ref: &mut VecZnxBigBackendMut<'_, BE> = &mut big;
+                ntt4x30_vec_znx_big_add_small_assign::<_, _, BE>(&mut big_ref, 0, &add, add_col);
+            }
+        }
+        let big_ref: poulpy_hal::layouts::VecZnxBigBackendRef<'_, BE> = VecZnxBig::from_data(&*big_bytes, n, 1, a_size);
+        let mut res_ref: &mut VecZnxBackendMut<'_, BE> = res;
+        ntt4x30_default_vec_znx_big_normalize::<_, _, BE>(&mut res_ref, res_base2k, 0, res_col, &&big_ref, a_base2k, 0, carry);
     }
 
     fn vec_znx_dft_add_into_default(
@@ -484,6 +616,23 @@ where
         for<'x> <BE as Backend>::BufRef<'x>: HostDataRef,
     {
         ntt4x30_default_vec_znx_dft_automorphism::<BE>(plan, res, res_col, a, a_col);
+    }
+
+    fn vec_znx_dft_automorphism_add_with_plan_default(
+        _module: &Module<BE>,
+        plan: &NttAutomorphismPlan,
+        res: &mut VecZnxDftBackendMut<'_, BE>,
+        res_col: usize,
+        a: &VecZnxDftBackendRef<'_, BE>,
+        a_col: usize,
+    ) where
+        BE: Backend<DftWord = Q120bScalar, ZnxWord = i64> + NttAddAssign,
+        for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
+        for<'x> <BE as Backend>::BufRef<'x>: HostDataRef,
+    {
+        ntt4x30_default_vec_znx_dft_automorphism_add::<BE, poulpy_hal::execution::SerialTaskExecutor>(
+            plan, res, res_col, a, a_col,
+        );
     }
 }
 

--- a/poulpy-cpu-ref/src/hal_defaults/vmp_pmat.rs
+++ b/poulpy-cpu-ref/src/hal_defaults/vmp_pmat.rs
@@ -9,8 +9,8 @@ use crate::reference::{
         reim::{ReimArith, ReimFFTExecute, ReimFFTTable},
         reim4::Reim4BlkMatVec,
         vmp::{
-            vmp_apply_dft_to_dft as fft64_vmp_apply_dft_to_dft,
-            vmp_apply_dft_to_dft_tmp_bytes as fft64_vmp_apply_dft_to_dft_tmp_bytes, vmp_prepare as fft64_vmp_prepare,
+            vmp_apply_dft_to_dft_tmp_bytes as fft64_vmp_apply_dft_to_dft_tmp_bytes,
+            vmp_apply_dft_to_dft_with_kernel as fft64_vmp_apply_dft_to_dft_with_kernel, vmp_prepare as fft64_vmp_prepare,
             vmp_prepare_tmp_bytes as fft64_vmp_prepare_tmp_bytes, vmp_zero as fft64_vmp_zero,
         },
     },
@@ -28,6 +28,7 @@ use crate::reference::{
 };
 use poulpy_hal::{
     api::{HostBufMut, ModuleN, ScratchArenaTakeBasic, VecZnxDftAddAssign, VecZnxDftBytesOf, VecZnxDftZero},
+    execution::TaskExecutor,
     layouts::{
         Backend, HostDataMut, HostDataRef, MatZnxBackendRef, Module, ScratchArena, VecZnxDftBackendMut, VecZnxDftBackendRef,
         VecZnxDftToBackendRef, VmpPMatBackendMut, VmpPMatBackendRef,
@@ -107,6 +108,7 @@ where
         fft64_vmp_apply_dft_to_dft_tmp_bytes(a_size, b_rows, b_cols_in)
     }
 
+    #[inline(always)]
     fn vmp_apply_dft_to_dft_default(
         _module: &Module<BE>,
         res: &mut VecZnxDftBackendMut<'_, BE>,
@@ -120,9 +122,31 @@ where
         for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
         for<'x> BE::BufMut<'x>: HostBufMut<'x>,
     {
-        let bytes = fft64_vmp_apply_dft_to_dft_tmp_bytes(a.size(), b.rows(), b.cols_in());
+        Self::vmp_apply_dft_to_dft_with_kernel_default::<BE, BE::TaskExecutor>(_module, res, a, b, limb_offset, 1, scratch);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[inline(always)]
+    fn vmp_apply_dft_to_dft_with_kernel_default<KERNEL, E>(
+        _module: &Module<BE>,
+        res: &mut VecZnxDftBackendMut<'_, BE>,
+        a: &VecZnxDftBackendRef<'_, BE>,
+        b: &VmpPMatBackendRef<'_, BE>,
+        limb_offset: usize,
+        workers: usize,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) where
+        BE: Backend<DftWord = f64, ZnxWord = i64>,
+        KERNEL: ReimArith + Reim4BlkMatVec,
+        E: TaskExecutor,
+        for<'x> <BE as Backend>::BufRef<'x>: HostDataRef,
+        for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
+        for<'x> BE::BufMut<'x>: HostBufMut<'x>,
+    {
+        let per_worker = fft64_vmp_apply_dft_to_dft_tmp_bytes(a.size(), b.rows(), b.cols_in());
+        let bytes = workers.max(1).min(scratch.available() / per_worker.max(1)).max(1) * per_worker;
         let (tmp, _) = take_host_typed::<BE, f64>(scratch.borrow(), bytes / size_of::<f64>());
-        fft64_vmp_apply_dft_to_dft::<BE>(res, a, b, limb_offset, tmp);
+        fft64_vmp_apply_dft_to_dft_with_kernel::<BE, KERNEL, E>(res, a, b, limb_offset, tmp);
     }
 
     fn vmp_apply_dft_to_dft_accumulate_tmp_bytes_default(
@@ -141,6 +165,7 @@ where
         module.bytes_of_vec_znx_dft(b_cols_out, res_size) + fft64_vmp_apply_dft_to_dft_tmp_bytes(a_size, b_rows, b_cols_in)
     }
 
+    #[inline(always)]
     fn vmp_apply_dft_to_dft_accumulate_default(
         module: &Module<BE>,
         res: &mut VecZnxDftBackendMut<'_, BE>,
@@ -155,15 +180,46 @@ where
         for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
         for<'x> BE::BufMut<'x>: HostBufMut<'x>,
     {
+        Self::vmp_apply_dft_to_dft_accumulate_with_kernel_default::<BE, BE::TaskExecutor>(
+            module,
+            res,
+            a,
+            b,
+            limb_offset,
+            1,
+            scratch,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[inline(always)]
+    fn vmp_apply_dft_to_dft_accumulate_with_kernel_default<KERNEL, E>(
+        module: &Module<BE>,
+        res: &mut VecZnxDftBackendMut<'_, BE>,
+        a: &VecZnxDftBackendRef<'_, BE>,
+        b: &VmpPMatBackendRef<'_, BE>,
+        limb_offset: usize,
+        workers: usize,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) where
+        Module<BE>: VecZnxDftBytesOf + ModuleN + VecZnxDftAddAssign<BE> + VecZnxDftZero<BE>,
+        BE: Backend<DftWord = f64, ZnxWord = i64>,
+        KERNEL: ReimArith + Reim4BlkMatVec,
+        E: TaskExecutor,
+        for<'x> <BE as Backend>::BufRef<'x>: HostDataRef,
+        for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
+        for<'x> BE::BufMut<'x>: HostBufMut<'x>,
+    {
         let cols_out = res.cols();
         let res_size = res.size();
         let (mut tmp, scratch_1) = scratch.borrow().take_vec_znx_dft_scratch(module, cols_out, res_size);
         for col in 0..cols_out {
             module.vec_znx_dft_zero(&mut tmp, col);
         }
-        let bytes = fft64_vmp_apply_dft_to_dft_tmp_bytes(a.size(), b.rows(), b.cols_in());
+        let per_worker = fft64_vmp_apply_dft_to_dft_tmp_bytes(a.size(), b.rows(), b.cols_in());
+        let bytes = workers.max(1).min(scratch_1.available() / per_worker.max(1)).max(1) * per_worker;
         let (kernel_tmp, _) = take_host_typed::<BE, f64>(scratch_1, bytes / size_of::<f64>());
-        fft64_vmp_apply_dft_to_dft::<BE>(&mut tmp, a, b, limb_offset, kernel_tmp);
+        fft64_vmp_apply_dft_to_dft_with_kernel::<BE, KERNEL, E>(&mut tmp, a, b, limb_offset, kernel_tmp);
         let tmp_ref = tmp.to_backend_ref();
         for col in 0..cols_out {
             module.vec_znx_dft_add_assign(res, col, &tmp_ref, col);

--- a/poulpy-cpu-ref/src/hal_impl/convolution.rs
+++ b/poulpy-cpu-ref/src/hal_impl/convolution.rs
@@ -80,6 +80,34 @@ macro_rules! hal_impl_convolution {
         }
 
         #[allow(clippy::too_many_arguments)]
+        fn cnv_by_const_apply_add(
+            module: &Module<Self>,
+            cnv_offset: usize,
+            mut res: &mut poulpy_hal::layouts::VecZnxBigBackendMut<'_, Self>,
+            res_col: usize,
+            a: &poulpy_hal::layouts::VecZnxBackendRef<'_, Self>,
+            a_col: usize,
+            b: &poulpy_hal::layouts::VecZnxBackendRef<'_, Self>,
+            b_col: usize,
+            b_coeff: usize,
+            scratch: &mut poulpy_hal::layouts::ScratchArena<'_, Self>,
+        ) {
+            let mut scratch = scratch.borrow();
+            <Self as $defaults<Self>>::cnv_by_const_apply_add_default(
+                module,
+                cnv_offset,
+                &mut res,
+                res_col,
+                a,
+                a_col,
+                b,
+                b_col,
+                b_coeff,
+                &mut scratch,
+            );
+        }
+
+        #[allow(clippy::too_many_arguments)]
         fn cnv_apply_dft(
             module: &Module<Self>,
             cnv_offset: usize,

--- a/poulpy-cpu-ref/src/hal_impl/delegating_backend.rs
+++ b/poulpy-cpu-ref/src/hal_impl/delegating_backend.rs
@@ -32,6 +32,8 @@ use crate::{
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub(crate) struct DelegatingFFT64Ref;
 
+impl poulpy_hal::execution::ScratchWorkers for DelegatingFFT64Ref {}
+
 poulpy_hal::impl_backend_from!(DelegatingFFT64Ref, FFT64Ref);
 
 macro_rules! impl_forward_znx_trait {

--- a/poulpy-cpu-ref/src/hal_impl/vec_znx.rs
+++ b/poulpy-cpu-ref/src/hal_impl/vec_znx.rs
@@ -1,5 +1,6 @@
+/// HAL `VecZnx` methods other than full-width normalization.
 #[macro_export]
-macro_rules! hal_impl_vec_znx {
+macro_rules! hal_impl_vec_znx_without_normalize {
     () => {
         fn scalar_znx_fill_ternary_hw_backend(
             module: &Module<Self>,
@@ -75,42 +76,6 @@ macro_rules! hal_impl_vec_znx {
 
         fn vec_znx_normalize_tmp_bytes_backend(module: &Module<Self>) -> usize {
             <Self as HalVecZnxDefault<Self>>::vec_znx_normalize_tmp_bytes_backend_default(module)
-        }
-
-        fn vec_znx_normalize_backend(
-            module: &Module<Self>,
-            res: &mut poulpy_hal::layouts::VecZnxBackendMut<'_, Self>,
-            res_base2k: usize,
-            res_offset: i64,
-            res_col: usize,
-            a: &poulpy_hal::layouts::VecZnxBackendRef<'_, Self>,
-            a_base2k: usize,
-            a_col: usize,
-            scratch: &mut poulpy_hal::layouts::ScratchArena<'_, Self>,
-        ) {
-            let mut scratch = scratch.borrow();
-            <Self as HalVecZnxDefault<Self>>::vec_znx_normalize_backend_default(
-                module,
-                res,
-                res_base2k,
-                res_offset,
-                res_col,
-                a,
-                a_base2k,
-                a_col,
-                &mut scratch,
-            );
-        }
-
-        fn vec_znx_normalize_assign_backend(
-            module: &Module<Self>,
-            base2k: usize,
-            a: &mut poulpy_hal::layouts::VecZnxBackendMut<'_, Self>,
-            a_col: usize,
-            scratch: &mut poulpy_hal::layouts::ScratchArena<'_, Self>,
-        ) {
-            let mut scratch = scratch.borrow();
-            <Self as HalVecZnxDefault<Self>>::vec_znx_normalize_assign_backend_default(module, base2k, a, a_col, &mut scratch);
         }
 
         fn vec_znx_normalize_coeff_assign_backend(
@@ -886,5 +851,55 @@ macro_rules! hal_impl_vec_znx {
                 seed,
             )
         }
+    };
+}
+
+/// Full-width HAL `VecZnx` normalization methods.
+#[macro_export]
+macro_rules! hal_impl_vec_znx_normalize {
+    () => {
+        fn vec_znx_normalize_backend(
+            module: &Module<Self>,
+            res: &mut poulpy_hal::layouts::VecZnxBackendMut<'_, Self>,
+            res_base2k: usize,
+            res_offset: i64,
+            res_col: usize,
+            a: &poulpy_hal::layouts::VecZnxBackendRef<'_, Self>,
+            a_base2k: usize,
+            a_col: usize,
+            scratch: &mut poulpy_hal::layouts::ScratchArena<'_, Self>,
+        ) {
+            let mut scratch = scratch.borrow();
+            <Self as HalVecZnxDefault<Self>>::vec_znx_normalize_backend_default(
+                module,
+                res,
+                res_base2k,
+                res_offset,
+                res_col,
+                a,
+                a_base2k,
+                a_col,
+                &mut scratch,
+            );
+        }
+
+        fn vec_znx_normalize_assign_backend(
+            module: &Module<Self>,
+            base2k: usize,
+            a: &mut poulpy_hal::layouts::VecZnxBackendMut<'_, Self>,
+            a_col: usize,
+            scratch: &mut poulpy_hal::layouts::ScratchArena<'_, Self>,
+        ) {
+            let mut scratch = scratch.borrow();
+            <Self as HalVecZnxDefault<Self>>::vec_znx_normalize_assign_backend_default(module, base2k, a, a_col, &mut scratch);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! hal_impl_vec_znx {
+    () => {
+        $crate::hal_impl_vec_znx_without_normalize!();
+        $crate::hal_impl_vec_znx_normalize!();
     };
 }

--- a/poulpy-cpu-ref/src/hal_impl/vec_znx_big.rs
+++ b/poulpy-cpu-ref/src/hal_impl/vec_znx_big.rs
@@ -1,5 +1,6 @@
+/// HAL `VecZnxBig` methods other than full-width normalization.
 #[macro_export]
-macro_rules! hal_impl_vec_znx_big {
+macro_rules! hal_impl_vec_znx_big_without_normalize {
     ($defaults:ident) => {
         fn vec_znx_big_from_small_backend(
             mut res: &mut poulpy_hal::layouts::VecZnxBigBackendMut<'_, Self>,
@@ -215,31 +216,6 @@ macro_rules! hal_impl_vec_znx_big {
             <Self as $defaults<Self>>::vec_znx_big_normalize_tmp_bytes_default(module)
         }
 
-        fn vec_znx_big_normalize(
-            module: &Module<Self>,
-            mut res: &mut poulpy_hal::layouts::VecZnxBackendMut<'_, Self>,
-            res_base2k: usize,
-            res_offset: i64,
-            res_col: usize,
-            a: &poulpy_hal::layouts::VecZnxBigBackendRef<'_, Self>,
-            a_base2k: usize,
-            a_col: usize,
-            scratch: &mut poulpy_hal::layouts::ScratchArena<'_, Self>,
-        ) {
-            let mut scratch = scratch.borrow();
-            <Self as $defaults<Self>>::vec_znx_big_normalize_default(
-                module,
-                &mut res,
-                res_base2k,
-                res_offset,
-                res_col,
-                &a,
-                a_base2k,
-                a_col,
-                &mut scratch,
-            );
-        }
-
         fn vec_znx_big_automorphism(
             module: &Module<Self>,
             k: i64,
@@ -265,5 +241,44 @@ macro_rules! hal_impl_vec_znx_big {
             let mut scratch = scratch.borrow();
             <Self as $defaults<Self>>::vec_znx_big_automorphism_assign_default(module, k, &mut res, res_col, &mut scratch);
         }
+    };
+}
+
+/// Full-width HAL `VecZnxBig` normalization.
+#[macro_export]
+macro_rules! hal_impl_vec_znx_big_normalize {
+    ($defaults:ident) => {
+        fn vec_znx_big_normalize(
+            module: &Module<Self>,
+            mut res: &mut poulpy_hal::layouts::VecZnxBackendMut<'_, Self>,
+            res_base2k: usize,
+            res_offset: i64,
+            res_col: usize,
+            a: &poulpy_hal::layouts::VecZnxBigBackendRef<'_, Self>,
+            a_base2k: usize,
+            a_col: usize,
+            scratch: &mut poulpy_hal::layouts::ScratchArena<'_, Self>,
+        ) {
+            let mut scratch = scratch.borrow();
+            <Self as $defaults<Self>>::vec_znx_big_normalize_default(
+                module,
+                &mut res,
+                res_base2k,
+                res_offset,
+                res_col,
+                &a,
+                a_base2k,
+                a_col,
+                &mut scratch,
+            );
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! hal_impl_vec_znx_big {
+    ($defaults:ident) => {
+        $crate::hal_impl_vec_znx_big_without_normalize!($defaults);
+        $crate::hal_impl_vec_znx_big_normalize!($defaults);
     };
 }

--- a/poulpy-cpu-ref/src/hal_impl/vec_znx_dft.rs
+++ b/poulpy-cpu-ref/src/hal_impl/vec_znx_dft.rs
@@ -82,6 +82,25 @@ macro_rules! __hal_impl_vec_znx_dft_common {
         ) {
             <Self as $defaults<Self>>::vec_znx_idft_apply_tmpa_default(module, res, res_col, a, a_col)
         }
+        fn vec_znx_idft_normalize_consume_tmp_bytes(module: &Module<Self>, res_size: usize, a_size: usize) -> usize {
+            <Self as $defaults<Self>>::vec_znx_idft_normalize_consume_tmp_bytes_default(module, res_size, a_size)
+        }
+
+        fn vec_znx_idft_normalize_consume(
+            module: &Module<Self>,
+            res: &mut poulpy_hal::layouts::VecZnxBackendMut<'_, Self>,
+            res_base2k: usize,
+            res_col: usize,
+            a: &mut poulpy_hal::layouts::VecZnxDftBackendMut<'_, Self>,
+            a_col: usize,
+            a_base2k: usize,
+            addend: Option<(&poulpy_hal::layouts::VecZnxBackendRef<'_, Self>, usize)>,
+            scratch: &mut poulpy_hal::layouts::ScratchArena<'_, Self>,
+        ) {
+            <Self as $defaults<Self>>::vec_znx_idft_normalize_consume_default(
+                module, res, res_base2k, res_col, a, a_col, a_base2k, addend, scratch,
+            )
+        }
 
         fn vec_znx_dft_add_into(
             module: &Module<Self>,
@@ -162,6 +181,17 @@ macro_rules! __hal_impl_vec_znx_dft_common {
 
         fn vec_znx_dft_zero(module: &Module<Self>, res: &mut poulpy_hal::layouts::VecZnxDftBackendMut<'_, Self>, res_col: usize) {
             <Self as $defaults<Self>>::vec_znx_dft_zero_default(module, res, res_col)
+        }
+
+        fn vec_znx_dft_automorphism_add_with_plan(
+            module: &Module<Self>,
+            plan: &Self::AutomorphismPlan,
+            res: &mut poulpy_hal::layouts::VecZnxDftBackendMut<'_, Self>,
+            res_col: usize,
+            a: &poulpy_hal::layouts::VecZnxDftBackendRef<'_, Self>,
+            a_col: usize,
+        ) {
+            <Self as $defaults<Self>>::vec_znx_dft_automorphism_add_with_plan_default(module, plan, res, res_col, a, a_col)
         }
     };
 }

--- a/poulpy-cpu-ref/src/ntt4x30/module.rs
+++ b/poulpy-cpu-ref/src/ntt4x30/module.rs
@@ -43,9 +43,12 @@ pub struct NTT4x30RefHandle {
     table_cache: crate::table_cache::ModuleTableCache,
 }
 
+impl poulpy_hal::execution::ScratchWorkers for NTT4x30Ref {}
+
 impl Backend for NTT4x30Ref {
     const DFT_IS_EXACT: bool = true;
 
+    type TaskExecutor = poulpy_hal::execution::SerialTaskExecutor;
     type DftWord = Q120bScalar;
     type ZnxWord = i64;
     type BigWord = i128;

--- a/poulpy-cpu-ref/src/reference/fft64/convolution.rs
+++ b/poulpy-cpu-ref/src/reference/fft64/convolution.rs
@@ -9,6 +9,7 @@ use crate::{
         vec_znx_dft::vec_znx_dft_apply,
     },
 };
+use poulpy_hal::execution::TaskExecutor;
 
 pub fn convolution_prepare_left<BE>(
     table: &ReimFFTTable<f64>,
@@ -58,6 +59,32 @@ fn convolution_prepare<R, BE>(
     let n: usize = table.m() << 1;
 
     let res_raw: &mut [f64] = res.raw_mut();
+
+    if BE::TaskExecutor::is_parallel() && cols * res_size > 1 && tmp.size() > 0 {
+        let res_addr = res_raw.as_mut_ptr() as usize;
+        BE::TaskExecutor::for_each_chunked(cols * res_size, tmp.raw_mut(), n, |limb, task| {
+            let col = task / res_size;
+            let j = task % res_size;
+            if j < min_size {
+                if j + 1 == min_size {
+                    BE::reim_from_znx_masked(limb, a.at(col, j), mask);
+                } else {
+                    BE::reim_from_znx(limb, a.at(col, j));
+                }
+                BE::reim_dft_execute(table, limb);
+            }
+            for blk_i in 0..m / 4 {
+                let off = col * n * res_size + blk_i * res_size * 8 + j * 8;
+                let dst = unsafe { std::slice::from_raw_parts_mut((res_addr as *mut f64).add(off), 8) };
+                if j < min_size {
+                    BE::reim4_extract_1blk_contiguous(m, 1, blk_i, dst, limb);
+                } else {
+                    dst.fill(0.0);
+                }
+            }
+        });
+        return;
+    }
 
     for i in 0..cols {
         // FFT all limbs (unmasked); the last active limb will be overwritten below.
@@ -111,6 +138,36 @@ pub fn convolution_prepare_self<BE>(
     let left_raw: &mut [f64] = left.raw_mut();
     let right_raw: &mut [f64] = right.raw_mut();
 
+    if BE::TaskExecutor::is_parallel() && cols * res_size > 1 && tmp.size() > 0 {
+        let left_addr = left_raw.as_mut_ptr() as usize;
+        let right_addr = right_raw.as_mut_ptr() as usize;
+        BE::TaskExecutor::for_each_chunked(cols * res_size, tmp.raw_mut(), n, |limb, task| {
+            let col = task / res_size;
+            let j = task % res_size;
+            if j < min_size {
+                if j + 1 == min_size {
+                    BE::reim_from_znx_masked(limb, a.at(col, j), mask);
+                } else {
+                    BE::reim_from_znx(limb, a.at(col, j));
+                }
+                BE::reim_dft_execute(table, limb);
+            }
+            for blk_i in 0..m / 4 {
+                let off = col * n * res_size + blk_i * res_size * 8 + j * 8;
+                let left_dst = unsafe { std::slice::from_raw_parts_mut((left_addr as *mut f64).add(off), 8) };
+                if j < min_size {
+                    BE::reim4_extract_1blk_contiguous(m, 1, blk_i, left_dst, limb);
+                } else {
+                    left_dst.fill(0.0);
+                }
+                unsafe {
+                    std::ptr::copy_nonoverlapping(left_dst.as_ptr(), (right_addr as *mut f64).add(off), 8);
+                }
+            }
+        });
+        return;
+    }
+
     for i in 0..cols {
         // FFT all limbs (unmasked); the last active limb will be overwritten below.
         vec_znx_dft_apply::<BE>(table, 1, 0, tmp, 0, a, i);
@@ -139,10 +196,48 @@ pub fn convolution_prepare_self<BE>(
 
 pub fn convolution_by_const_apply_tmp_bytes(res_size: usize, a_size: usize, b_size: usize) -> usize {
     let min_size: usize = res_size.min(a_size + b_size - 1);
-    size_of::<i64>() * (min_size + a_size) * 8
+    size_of::<i64>() * ((min_size + a_size) * 8 + b_size)
 }
 
 pub fn convolution_by_const_apply<BE>(
+    cnv_offset: usize,
+    res: &mut VecZnxBigBackendMut<'_, BE>,
+    res_col: usize,
+    a: &VecZnxBackendRef<'_, BE>,
+    a_col: usize,
+    b: &VecZnxBackendRef<'_, BE>,
+    b_col: usize,
+    b_coeff: usize,
+    tmp: &mut [i64],
+) where
+    BE: Backend<BigWord = i64, ZnxWord = i64> + I64Ops + 'static,
+    for<'x> BE: Backend<BufRef<'x> = &'x [u8], ZnxWord = i64>,
+    for<'x> <BE as Backend>::BufMut<'x>: crate::layouts::HostDataMut,
+{
+    convolution_by_const_apply_impl::<BE, false>(cnv_offset, res, res_col, a, a_col, b, b_col, b_coeff, tmp)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn convolution_by_const_apply_add<BE>(
+    cnv_offset: usize,
+    res: &mut VecZnxBigBackendMut<'_, BE>,
+    res_col: usize,
+    a: &VecZnxBackendRef<'_, BE>,
+    a_col: usize,
+    b: &VecZnxBackendRef<'_, BE>,
+    b_col: usize,
+    b_coeff: usize,
+    tmp: &mut [i64],
+) where
+    BE: Backend<BigWord = i64, ZnxWord = i64> + I64Ops + 'static,
+    for<'x> BE: Backend<BufRef<'x> = &'x [u8], ZnxWord = i64>,
+    for<'x> <BE as Backend>::BufMut<'x>: crate::layouts::HostDataMut,
+{
+    convolution_by_const_apply_impl::<BE, true>(cnv_offset, res, res_col, a, a_col, b, b_col, b_coeff, tmp)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn convolution_by_const_apply_impl<BE, const ADD: bool>(
     cnv_offset: usize,
     res: &mut VecZnxBigBackendMut<'_, BE>,
     res_col: usize,
@@ -177,20 +272,33 @@ pub fn convolution_by_const_apply<BE>(
     let a_idx: usize = n * a_col;
     let res_idx: usize = n * res_col;
 
-    let (res_blk, a_blk) = tmp[..(min_size + a_size) * 8].split_at_mut(min_size * 8);
-    let mut b_digits = vec![0i64; b_size];
+    let staging_size = min_size + a_size;
+    let (blocks, b_digits) = tmp[..staging_size * 8 + b_size].split_at_mut(staging_size * 8);
+    let (res_blk, a_blk) = blocks.split_at_mut(min_size * 8);
     for (j, digit) in b_digits.iter_mut().enumerate() {
         *digit = b.at(b_col, j)[b_coeff];
     }
 
     for blk_i in 0..n / 8 {
         BE::i64_extract_1blk_contiguous(a_sl, a_idx, a_size, blk_i, a_blk, a_raw);
-        BE::i64_convolution_by_const(res_blk, min_size, offset, a_blk, a_size, &b_digits);
+        BE::i64_convolution_by_const(res_blk, min_size, offset, a_blk, a_size, b_digits);
+        if ADD {
+            for start in (0..min_size).step_by(a_size) {
+                let rows = a_size.min(min_size - start);
+                BE::i64_extract_1blk_contiguous(res_sl, res_idx, rows, blk_i, a_blk, &res_raw[start * res_sl..]);
+                res_blk[8 * start..8 * (start + rows)]
+                    .iter_mut()
+                    .zip(a_blk.iter())
+                    .for_each(|(res, &value)| *res = res.wrapping_add(value));
+            }
+        }
         BE::i64_save_1blk_contiguous(res_sl, res_idx, min_size, blk_i, res_raw, res_blk);
     }
 
-    for j in min_size..res_size {
-        res.zero_at(res_col, j);
+    if !ADD {
+        for j in min_size..res_size {
+            res.zero_at(res_col, j);
+        }
     }
 }
 
@@ -338,10 +446,7 @@ pub fn convolution_pairwise_apply_dft<BE>(
     let a_size: usize = a.size();
     let b_size: usize = b.size();
 
-    assert_eq!(
-        tmp.len(),
-        convolution_pairwise_apply_dft_tmp_bytes(res_size, a_size, b_size) / size_of::<f64>()
-    );
+    assert!(tmp.len() >= convolution_pairwise_apply_dft_tmp_bytes(res_size, a_size, b_size) / size_of::<f64>());
 
     let bound: usize = a_size + b_size - 1;
     let min_size: usize = res_size.min(bound);

--- a/poulpy-cpu-ref/src/reference/fft64/vec_znx_dft.rs
+++ b/poulpy-cpu-ref/src/reference/fft64/vec_znx_dft.rs
@@ -6,6 +6,7 @@ use crate::{
         ZnxView, ZnxViewMut,
     },
     reference::{
+        SendPtr,
         fft64::reim::{ReimArith, ReimFFTExecute, ReimFFTTable, ReimIFFTTable},
         znx::ZnxZero,
     },
@@ -517,5 +518,41 @@ pub fn vec_znx_dft_automorphism<BE>(
 
     for limb in min_size..res_size {
         BE::reim_zero(res.at_mut(res_col, limb));
+    }
+}
+
+pub fn vec_znx_dft_automorphism_add<BE, E: poulpy_hal::execution::TaskExecutor>(
+    plan: &Fft64AutomorphismPlan,
+    res: &mut VecZnxDftBackendMut<'_, BE>,
+    res_col: usize,
+    a: &VecZnxDftBackendRef<'_, BE>,
+    a_col: usize,
+) where
+    BE: Backend<DftWord = f64, ZnxWord = i64>,
+    for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
+    for<'x> <BE as Backend>::BufRef<'x>: HostDataRef,
+{
+    let n = res.n();
+    let m = n >> 1;
+    let cols = res.cols();
+    let size = res.size().min(a.size());
+    let res_ptr = SendPtr::new(res.raw_mut().as_mut_ptr());
+    let apply = |limb: usize| {
+        let start = n * (limb * cols + res_col);
+        let res_limb = unsafe { std::slice::from_raw_parts_mut(res_ptr.get().add(start), n) };
+        let (res_re, res_im) = res_limb.split_at_mut(m);
+        let (a_re, a_im) = a.at(a_col, limb).split_at(m);
+        for (i, &source) in plan.perm.iter().enumerate() {
+            let source = source as usize;
+            res_re[i] += a_re[source];
+            res_im[i] += if plan.conj { -a_im[source] } else { a_im[source] };
+        }
+    };
+    if E::IS_PARALLEL {
+        E::for_each(size, apply);
+    } else {
+        for limb in 0..size {
+            apply(limb);
+        }
     }
 }

--- a/poulpy-cpu-ref/src/reference/fft64/vmp.rs
+++ b/poulpy-cpu-ref/src/reference/fft64/vmp.rs
@@ -5,11 +5,15 @@ use crate::{
         VecZnxDftToBackendMut, VecZnxToBackendRef, VmpPMatBackendMut, VmpPMatBackendRef, VmpPMatToBackendRef, ZnxView,
         ZnxViewMut,
     },
-    reference::fft64::{
-        reim::{ReimArith, ReimFFTExecute, ReimFFTTable},
-        reim4::Reim4BlkMatVec,
+    reference::{
+        SendPtr,
+        fft64::{
+            reim::{ReimArith, ReimFFTExecute, ReimFFTTable},
+            reim4::Reim4BlkMatVec,
+        },
     },
 };
+use poulpy_hal::execution::TaskExecutor;
 
 pub fn vmp_prepare_tmp_bytes(n: usize) -> usize {
     n * size_of::<i64>()
@@ -60,10 +64,10 @@ pub fn vmp_prepare<BE>(
 
     let nrows: usize = mat.cols_in() * mat.rows();
     let ncols: usize = mat.cols_out() * mat.size();
-    vmp_prepare_core::<BE>(table, pmat.raw_mut(), mat.raw(), nrows, ncols, tmp);
+    vmp_prepare_core::<BE, BE::TaskExecutor>(table, pmat.raw_mut(), mat.raw(), nrows, ncols, tmp);
 }
 
-pub(crate) fn vmp_prepare_core<REIM>(
+pub(crate) fn vmp_prepare_core<REIM, E>(
     table: &ReimFFTTable<f64>,
     pmat: &mut [f64],
     mat: &[i64],
@@ -72,6 +76,7 @@ pub(crate) fn vmp_prepare_core<REIM>(
     tmp: &mut [f64],
 ) where
     REIM: ReimArith + Reim4BlkMatVec + ReimFFTExecute<ReimFFTTable<f64>, f64>,
+    E: TaskExecutor,
 {
     let m: usize = table.m();
     let n: usize = m << 1;
@@ -81,29 +86,31 @@ pub(crate) fn vmp_prepare_core<REIM>(
         assert!(n >= 8);
         assert_eq!(mat.len(), n * nrows * ncols);
         assert_eq!(pmat.len(), n * nrows * ncols);
-        assert_eq!(tmp.len(), vmp_prepare_tmp_bytes(n) / size_of::<i64>())
+        assert!(tmp.len() >= vmp_prepare_tmp_bytes(n) / size_of::<i64>())
     }
 
     let offset: usize = nrows * ncols * 8;
+    let pmat_ptr = SendPtr::new(pmat.as_mut_ptr());
 
-    for row_i in 0..nrows {
+    E::for_each_chunked(nrows, tmp, n, |tmp, row_i| {
         for col_i in 0..ncols {
             let pos: usize = n * (row_i * ncols + col_i);
 
             REIM::reim_from_znx(tmp, &mat[pos..pos + n]);
             REIM::reim_dft_execute(table, tmp);
 
-            let dst: &mut [f64] = if col_i == (ncols - 1) && !ncols.is_multiple_of(2) {
-                &mut pmat[col_i * nrows * 8 + row_i * 8..]
+            let dst = if col_i == (ncols - 1) && !ncols.is_multiple_of(2) {
+                col_i * nrows * 8 + row_i * 8
             } else {
-                &mut pmat[(col_i / 2) * (nrows * 16) + row_i * 16 + (col_i % 2) * 8..]
+                (col_i / 2) * (nrows * 16) + row_i * 16 + (col_i % 2) * 8
             };
 
             for blk_i in 0..m >> 2 {
-                REIM::reim4_extract_1blk_contiguous(m, 1, blk_i, &mut dst[blk_i * offset..], tmp);
+                let dst = unsafe { std::slice::from_raw_parts_mut(pmat_ptr.get().add(dst + blk_i * offset), 8) };
+                REIM::reim4_extract_1blk_contiguous(m, 1, blk_i, dst, tmp);
             }
         }
-    }
+    });
 }
 
 pub fn vmp_apply_dft_tmp_bytes(n: usize, a_size: usize, prows: usize, pcols_in: usize) -> usize {
@@ -150,7 +157,16 @@ where
     let mut res_ref = res.to_backend_mut();
     let nrows: usize = pmat.cols_in() * pmat.rows();
     let ncols: usize = pmat.cols_out() * pmat.size();
-    vmp_apply_dft_to_dft_core::<true, BE>(n, res_ref.raw_mut(), a_dft.raw(), pmat.raw(), 0, nrows, ncols, tmp_bytes);
+    vmp_apply_dft_to_dft_core::<true, BE, BE::TaskExecutor>(
+        n,
+        res_ref.raw_mut(),
+        a_dft.raw(),
+        pmat.raw(),
+        0,
+        nrows,
+        ncols,
+        tmp_bytes,
+    );
 }
 
 pub fn vmp_apply_dft_to_dft_tmp_bytes(a_size: usize, prows: usize, pcols_in: usize) -> usize {
@@ -166,6 +182,7 @@ where
     res.raw_mut().fill(0.0);
 }
 
+#[inline(always)]
 pub fn vmp_apply_dft_to_dft<BE>(
     res: &mut VecZnxDftBackendMut<'_, BE>,
     a: &VecZnxDftBackendRef<'_, BE>,
@@ -174,6 +191,23 @@ pub fn vmp_apply_dft_to_dft<BE>(
     tmp_bytes: &mut [f64],
 ) where
     BE: Backend<DftWord = f64, ZnxWord = i64> + ReimArith + Reim4BlkMatVec,
+    for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
+    for<'x> <BE as Backend>::BufRef<'x>: HostDataRef,
+{
+    vmp_apply_dft_to_dft_with_kernel::<BE, BE, BE::TaskExecutor>(res, a, pmat, limb_offset, tmp_bytes);
+}
+
+#[inline(always)]
+pub fn vmp_apply_dft_to_dft_with_kernel<BE, KERNEL, E>(
+    res: &mut VecZnxDftBackendMut<'_, BE>,
+    a: &VecZnxDftBackendRef<'_, BE>,
+    pmat: &VmpPMatBackendRef<'_, BE>,
+    limb_offset: usize,
+    tmp_bytes: &mut [f64],
+) where
+    BE: Backend<DftWord = f64, ZnxWord = i64>,
+    KERNEL: ReimArith + Reim4BlkMatVec,
+    E: TaskExecutor,
     for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
     for<'x> <BE as Backend>::BufRef<'x>: HostDataRef,
 {
@@ -197,9 +231,9 @@ pub fn vmp_apply_dft_to_dft<BE>(
     // the runtime expression `limb_offset * pmat.cols_out()`. Blind rotation
     // always calls this with `limb_offset == 0`.
     if limb_offset == 0 {
-        vmp_apply_dft_to_dft_core::<true, BE>(n, res_raw, a_raw, pmat_raw, 0, nrows, ncols, tmp_bytes)
+        vmp_apply_dft_to_dft_core::<true, KERNEL, E>(n, res_raw, a_raw, pmat_raw, 0, nrows, ncols, tmp_bytes)
     } else {
-        vmp_apply_dft_to_dft_core::<true, BE>(
+        vmp_apply_dft_to_dft_core::<true, KERNEL, E>(
             n,
             res_raw,
             a_raw,
@@ -213,7 +247,77 @@ pub fn vmp_apply_dft_to_dft<BE>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn vmp_apply_dft_to_dft_core<const OVERWRITE: bool, REIM>(
+unsafe fn vmp_apply_dft_to_dft_block<const OVERWRITE: bool, REIM>(
+    n: usize,
+    m: usize,
+    res_addr: usize,
+    a: &[f64],
+    pmat: &[f64],
+    limb_offset: usize,
+    nrows: usize,
+    ncols: usize,
+    row_start: usize,
+    row_max: usize,
+    col_max: usize,
+    blk_i: usize,
+    tmp: &mut [f64],
+) where
+    REIM: ReimArith + Reim4BlkMatVec,
+{
+    let (mat2cols_output, extracted_blk) = tmp.split_at_mut(16);
+    let mat_blk_start = &pmat[blk_i * (8 * nrows * ncols)..];
+    REIM::reim4_extract_1blk_contiguous(m, row_max, blk_i, extracted_blk, &a[row_start * n..]);
+    let block_offset = 4 * blk_i;
+    let save = |col: usize, src: &[f64]| unsafe {
+        let base = (res_addr as *mut f64).add(col * n + block_offset);
+        if OVERWRITE {
+            std::ptr::copy_nonoverlapping(src.as_ptr(), base, 4);
+            std::ptr::copy_nonoverlapping(src.as_ptr().add(4), base.add(m), 4);
+        } else {
+            for i in 0..4 {
+                *base.add(i) += src[i];
+                *base.add(m + i) += src[4 + i];
+            }
+        }
+    };
+
+    if limb_offset.is_multiple_of(2) {
+        for (col_res, col_pmat) in (0..).step_by(2).zip((limb_offset..col_max - 1).step_by(2)) {
+            let col_offset = col_pmat * (8 * nrows) + row_start * 16;
+            REIM::reim4_mat2cols_prod(row_max, mat2cols_output, extracted_blk, &mat_blk_start[col_offset..]);
+            save(col_res, &mat2cols_output[..8]);
+            save(col_res + 1, &mat2cols_output[8..16]);
+        }
+    } else {
+        let col_offset = (limb_offset - 1) * (8 * nrows) + row_start * 16;
+        REIM::reim4_mat2cols_2ndcol_prod(row_max, mat2cols_output, extracted_blk, &mat_blk_start[col_offset..]);
+        save(0, &mat2cols_output[..8]);
+
+        for (col_res, col_pmat) in (1..).step_by(2).zip((limb_offset + 1..col_max - 1).step_by(2)) {
+            let col_offset = col_pmat * (8 * nrows) + row_start * 16;
+            REIM::reim4_mat2cols_prod(row_max, mat2cols_output, extracted_blk, &mat_blk_start[col_offset..]);
+            save(col_res, &mat2cols_output[..8]);
+            save(col_res + 1, &mat2cols_output[8..16]);
+        }
+    }
+
+    if !col_max.is_multiple_of(2) {
+        let last_col = col_max - 1;
+        let row_offset = if ncols == col_max { row_start * 8 } else { row_start * 16 };
+        let col_offset = last_col * (8 * nrows) + row_offset;
+        if last_col >= limb_offset {
+            if ncols == col_max {
+                REIM::reim4_mat1col_prod(row_max, mat2cols_output, extracted_blk, &mat_blk_start[col_offset..]);
+            } else {
+                REIM::reim4_mat2cols_prod(row_max, mat2cols_output, extracted_blk, &mat_blk_start[col_offset..]);
+            }
+            save(last_col - limb_offset, &mat2cols_output[..8]);
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn vmp_apply_dft_to_dft_core<const OVERWRITE: bool, REIM, E>(
     n: usize,
     res: &mut [f64],
     a: &[f64],
@@ -224,6 +328,7 @@ fn vmp_apply_dft_to_dft_core<const OVERWRITE: bool, REIM>(
     tmp_bytes: &mut [f64],
 ) where
     REIM: ReimArith + Reim4BlkMatVec,
+    E: TaskExecutor,
 {
     #[cfg(debug_assertions)]
     {
@@ -238,8 +343,6 @@ fn vmp_apply_dft_to_dft_core<const OVERWRITE: bool, REIM>(
     let res_size: usize = res.len() / n;
 
     let m: usize = n >> 1;
-
-    let (mat2cols_output, extracted_blk) = tmp_bytes.split_at_mut(16);
 
     let row_end: usize = nrows.min(a_size);
     let row_start = a
@@ -257,42 +360,45 @@ fn vmp_apply_dft_to_dft_core<const OVERWRITE: bool, REIM>(
         return;
     }
 
-    for blk_i in 0..(m >> 2) {
-        let mat_blk_start: &[f64] = &pmat[blk_i * (8 * nrows * ncols)..];
-
-        REIM::reim4_extract_1blk_contiguous(m, row_max, blk_i, extracted_blk, &a[row_start * n..]);
-
-        if limb_offset.is_multiple_of(2) {
-            for (col_res, col_pmat) in (0..).step_by(2).zip((limb_offset..col_max - 1).step_by(2)) {
-                let col_offset: usize = col_pmat * (8 * nrows) + row_start * 16;
-                REIM::reim4_mat2cols_prod(row_max, mat2cols_output, extracted_blk, &mat_blk_start[col_offset..]);
-                REIM::reim4_save_2blks::<OVERWRITE>(m, blk_i, &mut res[col_res * n..], mat2cols_output);
-            }
-        } else {
-            let col_offset: usize = (limb_offset - 1) * (8 * nrows) + row_start * 16;
-            REIM::reim4_mat2cols_2ndcol_prod(row_max, mat2cols_output, extracted_blk, &mat_blk_start[col_offset..]);
-
-            REIM::reim4_save_1blk::<OVERWRITE>(m, blk_i, res, mat2cols_output);
-
-            for (col_res, col_pmat) in (1..).step_by(2).zip((limb_offset + 1..col_max - 1).step_by(2)) {
-                let col_offset: usize = col_pmat * (8 * nrows) + row_start * 16;
-                REIM::reim4_mat2cols_prod(row_max, mat2cols_output, extracted_blk, &mat_blk_start[col_offset..]);
-                REIM::reim4_save_2blks::<OVERWRITE>(m, blk_i, &mut res[col_res * n..], mat2cols_output);
-            }
-        }
-
-        if !col_max.is_multiple_of(2) {
-            let last_col: usize = col_max - 1;
-            let row_offset = if ncols == col_max { row_start * 8 } else { row_start * 16 };
-            let col_offset: usize = last_col * (8 * nrows) + row_offset;
-
-            if last_col >= limb_offset {
-                if ncols == col_max {
-                    REIM::reim4_mat1col_prod(row_max, mat2cols_output, extracted_blk, &mat_blk_start[col_offset..]);
-                } else {
-                    REIM::reim4_mat2cols_prod(row_max, mat2cols_output, extracted_blk, &mat_blk_start[col_offset..]);
-                }
-                REIM::reim4_save_1blk::<OVERWRITE>(m, blk_i, &mut res[(last_col - limb_offset) * n..], mat2cols_output);
+    let block_count = m >> 2;
+    let task_tmp_len = 16 + 8 * row_max;
+    let res_addr = res.as_mut_ptr() as usize;
+    if E::is_parallel() && block_count > 1 {
+        E::for_each_chunked(block_count, tmp_bytes, task_tmp_len, |tmp, blk_i| unsafe {
+            vmp_apply_dft_to_dft_block::<OVERWRITE, REIM>(
+                n,
+                m,
+                res_addr,
+                a,
+                pmat,
+                limb_offset,
+                nrows,
+                ncols,
+                row_start,
+                row_max,
+                col_max,
+                blk_i,
+                tmp,
+            );
+        });
+    } else {
+        for blk_i in 0..block_count {
+            unsafe {
+                vmp_apply_dft_to_dft_block::<OVERWRITE, REIM>(
+                    n,
+                    m,
+                    res_addr,
+                    a,
+                    pmat,
+                    limb_offset,
+                    nrows,
+                    ncols,
+                    row_start,
+                    row_max,
+                    col_max,
+                    blk_i,
+                    tmp_bytes,
+                );
             }
         }
     }

--- a/poulpy-cpu-ref/src/reference/mod.rs
+++ b/poulpy-cpu-ref/src/reference/mod.rs
@@ -9,6 +9,23 @@ pub mod fft64;
 pub mod ntt4x30;
 pub mod vec_znx;
 
+#[derive(Clone, Copy)]
+pub(crate) struct SendPtr<T>(*mut T);
+
+impl<T> SendPtr<T> {
+    pub(crate) fn new(ptr: *mut T) -> Self {
+        Self(ptr)
+    }
+
+    pub(crate) fn get(self) -> *mut T {
+        self.0
+    }
+}
+
+// Dereferencing remains unsafe; users must enforce the pointee's aliasing rules.
+unsafe impl<T> Send for SendPtr<T> {}
+unsafe impl<T> Sync for SendPtr<T> {}
+
 /// Re-exported from [`poulpy_hal::reference::znx`], where the portable scalar
 /// kernels now live so that every crate can reach them without depending on a
 /// backend.

--- a/poulpy-cpu-ref/src/reference/ntt4x30/convolution.rs
+++ b/poulpy-cpu-ref/src/reference/ntt4x30/convolution.rs
@@ -10,6 +10,7 @@
 //! [`NttMulBbc1ColX2::ntt_mul_bbc_tile4_x2`].
 
 use bytemuck::{cast_slice, cast_slice_mut};
+use poulpy_hal::execution::TaskExecutor;
 
 use crate::{
     layouts::{
@@ -79,11 +80,16 @@ fn canonical_sum_row(dst: &mut [u32], a: &[u32], b: &[u32]) {
 ///   of overwriting.
 /// - `PAIRWISE`: operands are `(a0 + a1) mod q` and the lazy sum `b0 + b1`.
 #[allow(clippy::too_many_arguments)]
-fn ntt4x30_conv_columns<BE, const ACC: bool, const PAIRWISE: bool>(
-    module: &impl NttModuleHandle,
-    cnv_offset: usize,
-    res: &mut VecZnxDftBackendMut<'_, BE>,
+unsafe fn ntt4x30_conv_block_group<BE, const ACC: bool, const PAIRWISE: bool>(
+    module: &(impl NttModuleHandle + Sync),
+    res_addr: usize,
+    res_limb_words: usize,
+    res_cols: usize,
     res_col: usize,
+    min_size: usize,
+    offset: usize,
+    block_start: usize,
+    block_count: usize,
     a0_col: &[u32],
     a1_col: &[u32],
     a_size: usize,
@@ -96,15 +102,7 @@ fn ntt4x30_conv_columns<BE, const ACC: bool, const PAIRWISE: bool>(
     for<'x> <BE as Backend>::BufRef<'x>: HostDataRef,
     for<'x> <BE as Backend>::BufMut<'x>: crate::layouts::HostDataMut,
 {
-    let n = res.n();
-    let res_size = res.size();
-
-    let bound = a_size + b_size - 1;
-    let offset = cnv_offset.min(bound);
-    let min_size = res_size.min((bound + 1).saturating_sub(offset));
-
     let meta = module.get_bbc_meta();
-    let n_blks = n / 2;
     let pad = TILE - 1;
     let win_rows = a_size + 2 * pad;
 
@@ -122,7 +120,8 @@ fn ntt4x30_conv_columns<BE, const ACC: bool, const PAIRWISE: bool>(
     let n_tiles = min_size.div_ceil(TILE);
     let mut out = [0u64; 8 * TILE];
 
-    for blk in 0..n_blks {
+    for local_blk in 0..block_count {
+        let blk = block_start + local_blk;
         // Stage this block's a rows (or the canonical pairwise sum) into the
         // padded window; b rows are read in place (lazy-summed when PAIRWISE).
         let a_blk = &a0_col[blk * 16 * a_size..(blk + 1) * 16 * a_size];
@@ -149,7 +148,7 @@ fn ntt4x30_conv_columns<BE, const ACC: bool, const PAIRWISE: bool>(
             &b0_col[blk * 16 * b_size..(blk + 1) * 16 * b_size]
         };
 
-        let grp_pos = blk % CNV_ACC_GROUP;
+        let grp_pos = local_blk;
 
         for tile in 0..n_tiles {
             let k0 = offset + TILE * tile;
@@ -177,17 +176,102 @@ fn ntt4x30_conv_columns<BE, const ACC: bool, const PAIRWISE: bool>(
         }
 
         // Flush the group per limb as one contiguous run.
-        let in_group = grp_pos + 1;
-        if in_group == CNV_ACC_GROUP || blk == n_blks - 1 {
-            let grp_base = blk + 1 - in_group;
-            for k in 0..min_size {
-                let res_u64: &mut [u64] = cast_slice_mut(res.at_mut(res_col, k));
-                let run = &stage[8 * k * CNV_ACC_GROUP..8 * (k * CNV_ACC_GROUP + in_group)];
-                if ACC {
-                    BE::ntt_add_assign(&mut res_u64[8 * grp_base..8 * (grp_base + in_group)], run);
-                } else {
-                    res_u64[8 * grp_base..8 * (grp_base + in_group)].copy_from_slice(run);
-                }
+    }
+
+    for k in 0..min_size {
+        let dst = unsafe {
+            std::slice::from_raw_parts_mut(
+                (res_addr as *mut u64).add(res_limb_words * (k * res_cols + res_col) + 8 * block_start),
+                8 * block_count,
+            )
+        };
+        let run = &stage[8 * k * CNV_ACC_GROUP..8 * (k * CNV_ACC_GROUP + block_count)];
+        if ACC {
+            BE::ntt_add_assign(dst, run);
+        } else {
+            dst.copy_from_slice(run);
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ntt4x30_conv_columns<BE, const ACC: bool, const PAIRWISE: bool>(
+    module: &(impl NttModuleHandle + Sync),
+    cnv_offset: usize,
+    res: &mut VecZnxDftBackendMut<'_, BE>,
+    res_col: usize,
+    a0_col: &[u32],
+    a1_col: &[u32],
+    a_size: usize,
+    b0_col: &[u32],
+    b1_col: &[u32],
+    b_size: usize,
+    tmp: &mut [u8],
+) where
+    BE: Backend<DftWord = Q120bScalar, ZnxWord = i64> + NttAddAssign + NttMulBbc1ColX2,
+    for<'x> <BE as Backend>::BufRef<'x>: HostDataRef,
+    for<'x> <BE as Backend>::BufMut<'x>: crate::layouts::HostDataMut,
+{
+    let n = res.n();
+    let res_size = res.size();
+    let bound = a_size + b_size - 1;
+    let offset = cnv_offset.min(bound);
+    let min_size = res_size.min((bound + 1).saturating_sub(offset));
+    let n_blks = n / 2;
+    let group_count = n_blks.div_ceil(CNV_ACC_GROUP);
+    let res_limb_words = cast_slice::<Q120bScalar, u64>(res.at(res_col, 0)).len();
+    let res_cols = res.cols();
+    let res_addr = cast_slice_mut::<Q120bScalar, u64>(res.raw_mut()).as_mut_ptr() as usize;
+    let task_tmp_bytes = if PAIRWISE {
+        ntt4x30_cnv_pairwise_apply_dft_tmp_bytes(res_size, a_size, b_size)
+    } else {
+        ntt4x30_cnv_apply_dft_tmp_bytes(res_size, a_size, b_size)
+    };
+
+    if BE::TaskExecutor::is_parallel() && group_count > 1 {
+        BE::TaskExecutor::for_each_chunked(group_count, tmp, task_tmp_bytes, |local_tmp, group| unsafe {
+            let block_start = group * CNV_ACC_GROUP;
+            ntt4x30_conv_block_group::<BE, ACC, PAIRWISE>(
+                module,
+                res_addr,
+                res_limb_words,
+                res_cols,
+                res_col,
+                min_size,
+                offset,
+                block_start,
+                CNV_ACC_GROUP.min(n_blks - block_start),
+                a0_col,
+                a1_col,
+                a_size,
+                b0_col,
+                b1_col,
+                b_size,
+                local_tmp,
+            );
+        });
+    } else {
+        for group in 0..group_count {
+            let block_start = group * CNV_ACC_GROUP;
+            unsafe {
+                ntt4x30_conv_block_group::<BE, ACC, PAIRWISE>(
+                    module,
+                    res_addr,
+                    res_limb_words,
+                    res_cols,
+                    res_col,
+                    min_size,
+                    offset,
+                    block_start,
+                    CNV_ACC_GROUP.min(n_blks - block_start),
+                    a0_col,
+                    a1_col,
+                    a_size,
+                    b0_col,
+                    b1_col,
+                    b_size,
+                    tmp,
+                );
             }
         }
     }
@@ -213,7 +297,7 @@ fn col_slice_u32(raw: &[Q120bScalar], n: usize, size: usize, col: usize) -> &[u3
 /// Output limbs `min_size..res.size()` are zeroed.
 #[allow(clippy::too_many_arguments)]
 pub fn ntt4x30_cnv_apply_dft<BE>(
-    module: &impl NttModuleHandle,
+    module: &(impl NttModuleHandle + Sync),
     cnv_offset: usize,
     res: &mut VecZnxDftBackendMut<'_, BE>,
     res_col: usize,
@@ -250,7 +334,7 @@ pub fn ntt4x30_cnv_apply_dft<BE>(
 /// Limbs `>= min_size` are left untouched.
 #[allow(clippy::too_many_arguments)]
 pub fn ntt4x30_cnv_apply_dft_accumulate<BE>(
-    module: &impl NttModuleHandle,
+    module: &(impl NttModuleHandle + Sync),
     cnv_offset: usize,
     res: &mut VecZnxDftBackendMut<'_, BE>,
     res_col: usize,
@@ -427,7 +511,7 @@ pub fn ntt4x30_cnv_accumulate_dft<BE>(
 /// When `col_i == col_j` this delegates to [`ntt4x30_cnv_apply_dft`].
 #[allow(clippy::too_many_arguments)]
 pub fn ntt4x30_cnv_pairwise_apply_dft<BE>(
-    module: &impl NttModuleHandle,
+    module: &(impl NttModuleHandle + Sync),
     cnv_offset: usize,
     res: &mut VecZnxDftBackendMut<'_, BE>,
     res_col: usize,
@@ -508,10 +592,42 @@ pub fn ntt4x30_cnv_prepare_left<BE>(
     let (prefix, tmp_u64, suffix) = unsafe { tmp.align_to_mut::<u64>() };
     debug_assert!(prefix.is_empty());
     debug_assert!(suffix.is_empty());
+    let res_u32: &mut [u32] = cast_slice_mut(res.raw_mut());
+    if BE::TaskExecutor::is_parallel() && cols * res_size > 1 {
+        let res_addr = res_u32.as_mut_ptr() as usize;
+        BE::TaskExecutor::for_each_chunked(cols * res_size, tmp_u64, 8 * n, |task_tmp, task| {
+            let col = task / res_size;
+            let j = task % res_size;
+            let (limb, canon_u64) = task_tmp.split_at_mut(4 * n);
+            let canon: &mut [u32] = cast_slice_mut(canon_u64);
+            if j < min_size {
+                if j + 1 == min_size {
+                    BE::ntt_from_znx64_masked(limb, a.at(col, j), mask);
+                } else {
+                    BE::ntt_from_znx64(limb, a.at(col, j));
+                }
+                BE::ntt_dft_execute(table, limb);
+            }
+            for g in (0..n_blks).step_by(PREP_GROUP) {
+                let gl = PREP_GROUP.min(n_blks - g);
+                if j < min_size {
+                    BE::ntt_pack_left_1blk_x2(&mut canon[..16 * gl], &limb[8 * g..], gl, 8, 0);
+                }
+                for i in 0..gl {
+                    let off = col * col_stride + ((g + i) * res_size + j) * 16;
+                    let dst = unsafe { std::slice::from_raw_parts_mut((res_addr as *mut u32).add(off), 16) };
+                    if j < min_size {
+                        dst.copy_from_slice(&canon[16 * i..16 * (i + 1)]);
+                    } else {
+                        dst.fill(0);
+                    }
+                }
+            }
+        });
+        return;
+    }
     let (limb, canon_u64) = tmp_u64[..8 * n].split_at_mut(4 * n);
     let canon: &mut [u32] = cast_slice_mut(canon_u64);
-
-    let res_u32: &mut [u32] = cast_slice_mut(res.raw_mut());
     for col in 0..cols {
         let dst = &mut res_u32[col * col_stride..(col + 1) * col_stride];
         for j in 0..min_size {
@@ -563,10 +679,38 @@ pub fn ntt4x30_cnv_prepare_right<BE>(
     let n_blks = n / 2;
     let col_stride = 8 * n * res_size;
 
+    let res_u32: &mut [u32] = cast_slice_mut(res.raw_mut());
+    if BE::TaskExecutor::is_parallel() && cols * res_size > 1 {
+        let res_addr = res_u32.as_mut_ptr() as usize;
+        BE::TaskExecutor::for_each_chunked(cols * res_size, tmp, 8 * n, |task_tmp, task| {
+            let col = task / res_size;
+            let j = task % res_size;
+            let (limb_b, limb_c_u64) = task_tmp.split_at_mut(4 * n);
+            let limb_c: &mut [u32] = cast_slice_mut(limb_c_u64);
+            if j < min_size {
+                if j + 1 == min_size {
+                    BE::ntt_from_znx64_masked(limb_b, a.at(col, j), mask);
+                } else {
+                    BE::ntt_from_znx64(limb_b, a.at(col, j));
+                }
+                BE::ntt_dft_execute(table, limb_b);
+                BE::ntt_c_from_b(n, limb_c, limb_b);
+            }
+            let row = res_size - 1 - j;
+            for blk in 0..n_blks {
+                let off = col * col_stride + (blk * res_size + row) * 16;
+                let dst = unsafe { std::slice::from_raw_parts_mut((res_addr as *mut u32).add(off), 16) };
+                if j < min_size {
+                    dst.copy_from_slice(&limb_c[16 * blk..16 * (blk + 1)]);
+                } else {
+                    dst.fill(0);
+                }
+            }
+        });
+        return;
+    }
     let (limb_b, limb_c_u64) = tmp[..8 * n].split_at_mut(4 * n);
     let limb_c: &mut [u32] = cast_slice_mut(limb_c_u64);
-
-    let res_u32: &mut [u32] = cast_slice_mut(res.raw_mut());
     for col in 0..cols {
         let dst = &mut res_u32[col * col_stride..(col + 1) * col_stride];
         for j in 0..min_size {
@@ -624,13 +768,59 @@ pub fn ntt4x30_cnv_prepare_self<BE>(
     let (prefix, tmp_u64, suffix) = unsafe { tmp.align_to_mut::<u64>() };
     debug_assert!(prefix.is_empty());
     debug_assert!(suffix.is_empty());
+    let left_u32: &mut [u32] = cast_slice_mut(left.raw_mut());
+    let right_u32: &mut [u32] = cast_slice_mut(right.raw_mut());
+    if BE::TaskExecutor::is_parallel() && cols * res_size > 1 {
+        let left_addr = left_u32.as_mut_ptr() as usize;
+        let right_addr = right_u32.as_mut_ptr() as usize;
+        BE::TaskExecutor::for_each_chunked(cols * res_size, tmp_u64, 12 * n, |task_tmp, task| {
+            let col = task / res_size;
+            let j = task % res_size;
+            let (limb_b, rest) = task_tmp.split_at_mut(4 * n);
+            let (canon_u64, limb_c_u64) = rest.split_at_mut(4 * n);
+            let canon: &mut [u32] = cast_slice_mut(canon_u64);
+            let limb_c: &mut [u32] = cast_slice_mut(limb_c_u64);
+            if j < min_size {
+                if j + 1 == min_size {
+                    BE::ntt_from_znx64_masked(limb_b, a.at(col, j), mask);
+                } else {
+                    BE::ntt_from_znx64(limb_b, a.at(col, j));
+                }
+                BE::ntt_dft_execute(table, limb_b);
+                BE::ntt_c_from_b(n, limb_c, limb_b);
+            }
+            for g in (0..n_blks).step_by(PREP_GROUP) {
+                let gl = PREP_GROUP.min(n_blks - g);
+                if j < min_size {
+                    BE::ntt_pack_left_1blk_x2(&mut canon[..16 * gl], &limb_b[8 * g..], gl, 8, 0);
+                }
+                for i in 0..gl {
+                    let left_off = col * col_stride + ((g + i) * res_size + j) * 16;
+                    let left_dst = unsafe { std::slice::from_raw_parts_mut((left_addr as *mut u32).add(left_off), 16) };
+                    if j < min_size {
+                        left_dst.copy_from_slice(&canon[16 * i..16 * (i + 1)]);
+                    } else {
+                        left_dst.fill(0);
+                    }
+                }
+            }
+            let row = res_size - 1 - j;
+            for blk in 0..n_blks {
+                let right_off = col * col_stride + (blk * res_size + row) * 16;
+                let right_dst = unsafe { std::slice::from_raw_parts_mut((right_addr as *mut u32).add(right_off), 16) };
+                if j < min_size {
+                    right_dst.copy_from_slice(&limb_c[16 * blk..16 * (blk + 1)]);
+                } else {
+                    right_dst.fill(0);
+                }
+            }
+        });
+        return;
+    }
     let (limb_b, rest) = tmp_u64[..12 * n].split_at_mut(4 * n);
     let (canon_u64, limb_c_u64) = rest.split_at_mut(4 * n);
     let canon: &mut [u32] = cast_slice_mut(canon_u64);
     let limb_c: &mut [u32] = cast_slice_mut(limb_c_u64);
-
-    let left_u32: &mut [u32] = cast_slice_mut(left.raw_mut());
-    let right_u32: &mut [u32] = cast_slice_mut(right.raw_mut());
     for col in 0..cols {
         let dst_l = &mut left_u32[col * col_stride..(col + 1) * col_stride];
         let dst_r = &mut right_u32[col * col_stride..(col + 1) * col_stride];
@@ -677,7 +867,7 @@ pub fn ntt4x30_cnv_by_const_apply_tmp_bytes(_res_size: usize, _a_size: usize, _b
 /// Each output limb is computed as an `i128` inner product. Output limbs
 /// `min_size..res.size()` are zeroed. `_tmp` is unused.
 #[allow(clippy::too_many_arguments)]
-pub fn ntt4x30_cnv_by_const_apply<BE>(
+pub fn ntt4x30_cnv_by_const_apply<BE, E: TaskExecutor>(
     cnv_offset: usize,
     res: &mut VecZnxBigBackendMut<'_, BE>,
     res_col: usize,
@@ -692,12 +882,51 @@ pub fn ntt4x30_cnv_by_const_apply<BE>(
     for<'x> BE: Backend<BufRef<'x> = &'x [u8], ZnxWord = i64>,
     for<'x> <BE as Backend>::BufMut<'x>: crate::layouts::HostDataMut,
 {
+    ntt4x30_cnv_by_const_apply_impl::<BE, E, false>(cnv_offset, res, res_col, a, a_col, b, b_col, b_coeff)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn ntt4x30_cnv_by_const_apply_add<BE, E: TaskExecutor>(
+    cnv_offset: usize,
+    res: &mut VecZnxBigBackendMut<'_, BE>,
+    res_col: usize,
+    a: &VecZnxBackendRef<'_, BE>,
+    a_col: usize,
+    b: &VecZnxBackendRef<'_, BE>,
+    b_col: usize,
+    b_coeff: usize,
+    _tmp: &mut [u8],
+) where
+    BE: Backend<DftWord = Q120bScalar, BigWord = i128, ZnxWord = i64> + 'static,
+    for<'x> BE: Backend<BufRef<'x> = &'x [u8], ZnxWord = i64>,
+    for<'x> <BE as Backend>::BufMut<'x>: crate::layouts::HostDataMut,
+{
+    ntt4x30_cnv_by_const_apply_impl::<BE, E, true>(cnv_offset, res, res_col, a, a_col, b, b_col, b_coeff)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ntt4x30_cnv_by_const_apply_impl<BE, E: TaskExecutor, const ADD: bool>(
+    cnv_offset: usize,
+    res: &mut VecZnxBigBackendMut<'_, BE>,
+    res_col: usize,
+    a: &VecZnxBackendRef<'_, BE>,
+    a_col: usize,
+    b: &VecZnxBackendRef<'_, BE>,
+    b_col: usize,
+    b_coeff: usize,
+) where
+    BE: Backend<DftWord = Q120bScalar, BigWord = i128, ZnxWord = i64> + 'static,
+    for<'x> BE: Backend<BufRef<'x> = &'x [u8], ZnxWord = i64>,
+    for<'x> <BE as Backend>::BufMut<'x>: crate::layouts::HostDataMut,
+{
     let res_size = res.size();
     let a_size = a.size();
     let b_size = b.size();
     if res_size == 0 || a_size == 0 || b_size == 0 {
-        for j in 0..res_size {
-            res.at_mut(res_col, j).fill(0i128);
+        if !ADD {
+            for j in 0..res_size {
+                res.at_mut(res_col, j).fill(0i128);
+            }
         }
         return;
     }
@@ -706,23 +935,36 @@ pub fn ntt4x30_cnv_by_const_apply<BE>(
     let offset = cnv_offset.min(bound);
     let min_size = res_size.min((bound + 1).saturating_sub(offset));
 
-    for k in 0..min_size {
+    let n = res.n();
+    let res_cols = res.cols();
+    let res_ptr = crate::reference::SendPtr::new(res.raw_mut().as_mut_ptr());
+    let process = |k: usize| {
+        let res_limb = unsafe { std::slice::from_raw_parts_mut(res_ptr.get().add(n * (k * res_cols + res_col)), n) };
+        if k >= min_size {
+            if !ADD {
+                res_limb.fill(0);
+            }
+            return;
+        }
         let k_abs = k + offset;
         let j_min = k_abs.saturating_sub(a_size - 1);
         let j_max = (k_abs + 1).min(b_size);
-        let res_limb: &mut [i128] = res.at_mut(res_col, k);
         for (n_i, r) in res_limb.iter_mut().enumerate() {
             let mut acc: i128 = 0;
             for j in j_min..j_max {
                 let b_j = b.at(b_col, j)[b_coeff];
                 acc += a.at(a_col, k_abs - j)[n_i] as i128 * b_j as i128;
             }
-            *r = acc;
+            *r = if ADD { (*r).wrapping_add(acc) } else { acc };
         }
-    }
+    };
 
-    for j in min_size..res_size {
-        res.at_mut(res_col, j).fill(0i128);
+    if E::IS_PARALLEL {
+        E::for_each(res_size, process);
+    } else {
+        for k in 0..res_size {
+            process(k);
+        }
     }
 }
 

--- a/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_big.rs
+++ b/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_big.rs
@@ -37,7 +37,10 @@ use crate::{
         Backend, HostDataMut, HostDataRef, NoiseInfos, VecZnxBigToBackendMut, VecZnxBigToBackendRef, VecZnxToBackendMut,
         VecZnxToBackendRef, ZnxView, ZnxViewMut,
     },
-    reference::znx::{get_carry_i128, get_digit_i128},
+    reference::{
+        vec_znx::VecZnxRangeMut,
+        znx::{get_carry_i128, get_digit_i128},
+    },
     source::Source,
 };
 
@@ -374,29 +377,27 @@ fn nfc_extract_digit_assignmul<O: AssignOp>(base2k: usize, scale: usize, res: &m
 /// Structurally identical to `vec_znx_normalize_inter_base2k` but with `i128` input
 /// and `i128` carry (the output `res` is `i64`).
 #[allow(clippy::too_many_arguments)]
-fn ntt4x30_vec_znx_big_normalize_inter<R, A, BE>(
+fn ntt4x30_vec_znx_big_normalize_inter<A, BE>(
     base2k: usize,
-    res: &mut R,
+    res: &mut VecZnxRangeMut<'_>,
+    res_size: usize,
     res_offset: i64,
-    res_col: usize,
     a: &A,
     a_col: usize,
+    coeff_start: usize,
+    coeff_len: usize,
     carry: &mut [i128],
 ) where
-    R: VecZnxToBackendMut<BE>,
     A: VecZnxBigToBackendRef<BE>,
     BE: Backend<BigWord = i128, ZnxWord = i64> + I128NormalizeOps,
-    for<'x> BE::BufMut<'x>: HostDataMut,
     for<'x> BE::BufRef<'x>: HostDataRef,
 {
-    let mut res = res.to_backend_mut();
     let a = a.to_backend_ref();
 
-    let n = res.n();
-    let res_size = res.size();
+    let (lo, hi) = (coeff_start, coeff_start + coeff_len);
     let a_size = a.size();
 
-    let (carry, _) = carry.split_at_mut(n);
+    let (carry, _) = carry.split_at_mut(coeff_len);
 
     let mut lsh: i64 = res_offset % base2k as i64;
     let mut limbs_offset: i64 = res_offset / base2k as i64;
@@ -418,9 +419,9 @@ fn ntt4x30_vec_znx_big_normalize_inter<R, A, BE>(
     // Compute carry over discarded a limbs (those beyond res capacity).
     for j in 0..a_out_range {
         if j == 0 {
-            nfc_first_carry_only(base2k, lsh_pos, a.at(a_col, a_size - j - 1), carry);
+            nfc_first_carry_only(base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], carry);
         } else {
-            nfc_middle_carry_only(base2k, lsh_pos, a.at(a_col, a_size - j - 1), carry);
+            nfc_middle_carry_only(base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], carry);
         }
     }
 
@@ -430,7 +431,7 @@ fn ntt4x30_vec_znx_big_normalize_inter<R, A, BE>(
 
     // Zero bottom res limbs that will not receive a value.
     for j in res_start..res_size {
-        res.at_mut(res_col, j).fill(0);
+        res.at_mut(j).fill(0);
     }
 
     let mid_range: usize = a_start.saturating_sub(a_end);
@@ -440,19 +441,19 @@ fn ntt4x30_vec_znx_big_normalize_inter<R, A, BE>(
         BE::nfc_middle_step(
             base2k,
             lsh_pos,
-            res.at_mut(res_col, res_start - j - 1),
-            a.at(a_col, a_start - j - 1),
+            res.at_mut(res_start - j - 1),
+            &a.at(a_col, a_start - j - 1)[lo..hi],
             carry,
         );
     }
 
     // Propagate carry to remaining lower res limbs (which were zeroed above).
     for j in 0..res_end {
-        res.at_mut(res_col, res_end - j - 1).fill(0);
+        res.at_mut(res_end - j - 1).fill(0);
         if j == res_end - 1 {
-            BE::nfc_final_step_assign(base2k, lsh_pos, res.at_mut(res_col, res_end - j - 1), carry);
+            BE::nfc_final_step_assign(base2k, lsh_pos, res.at_mut(res_end - j - 1), carry);
         } else {
-            BE::nfc_middle_step_assign(base2k, lsh_pos, res.at_mut(res_col, res_end - j - 1), carry);
+            BE::nfc_middle_step_assign(base2k, lsh_pos, res.at_mut(res_end - j - 1), carry);
         }
     }
 }
@@ -538,32 +539,30 @@ fn ntt4x30_vec_znx_big_normalize_inter_assign<O, R, A, BE>(
 /// Structurally identical to `vec_znx_normalize_cross_base2k` but with `i128` input
 /// limbs, `i128` carry buffers, and `i64` output.
 #[allow(clippy::too_many_arguments)]
-fn ntt4x30_vec_znx_big_normalize_cross<R, A, BE>(
-    res: &mut R,
+fn ntt4x30_vec_znx_big_normalize_cross<A, BE>(
+    res: &mut VecZnxRangeMut<'_>,
+    res_size: usize,
     res_base2k: usize,
     res_offset: i64,
-    res_col: usize,
     a: &A,
     a_base2k: usize,
     a_col: usize,
-    carry: &mut [i128], // 3 * n elements
+    coeff_start: usize,
+    coeff_len: usize,
+    carry: &mut [i128], // 3 * coeff_len elements
 ) where
-    R: VecZnxToBackendMut<BE>,
     A: VecZnxBigToBackendRef<BE>,
     BE: Backend<BigWord = i128, ZnxWord = i64> + I128NormalizeOps,
-    for<'x> BE::BufMut<'x>: HostDataMut,
     for<'x> BE::BufRef<'x>: HostDataRef,
 {
-    let mut res = res.to_backend_mut();
     let a = a.to_backend_ref();
 
-    let n = res.n();
-    let res_size = res.size();
+    let (lo, hi) = (coeff_start, coeff_start + coeff_len);
     let a_size = a.size();
 
     // Partition the scratch: [a_norm | res_carry | a_carry]
-    let (a_norm, carry) = carry.split_at_mut(n);
-    let (res_carry, a_carry) = carry[..2 * n].split_at_mut(n);
+    let (a_norm, carry) = carry.split_at_mut(coeff_len);
+    let (res_carry, a_carry) = carry[..2 * coeff_len].split_at_mut(coeff_len);
     nfc_zero(res_carry);
 
     let a_tot_bits: usize = a_size * a_base2k;
@@ -591,7 +590,7 @@ fn ntt4x30_vec_znx_big_normalize_cross<R, A, BE>(
 
     // Zero all res limbs.
     for j in 0..res_size {
-        res.at_mut(res_col, j).fill(0);
+        res.at_mut(j).fill(0);
     }
 
     if res_start == 0 {
@@ -602,9 +601,9 @@ fn ntt4x30_vec_znx_big_normalize_cross<R, A, BE>(
     let a_out_range: usize = a_size.saturating_sub(a_start);
     for j in 0..a_out_range {
         if j == 0 {
-            nfc_first_carry_only(a_base2k, lsh_pos, a.at(a_col, a_size - j - 1), a_carry);
+            nfc_first_carry_only(a_base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], a_carry);
         } else {
-            nfc_middle_carry_only(a_base2k, lsh_pos, a.at(a_col, a_size - j - 1), a_carry);
+            nfc_middle_carry_only(a_base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], a_carry);
         }
     }
     if a_out_range == 0 {
@@ -618,7 +617,7 @@ fn ntt4x30_vec_znx_big_normalize_cross<R, A, BE>(
 
     'outer: for j in 0..mid_range {
         let a_limb: usize = a_start - j - 1;
-        let a_slice: &[i128] = a.at(a_col, a_limb);
+        let a_slice: &[i128] = &a.at(a_col, a_limb)[lo..hi];
 
         let mut a_take_left: usize = a_base2k;
 
@@ -636,7 +635,7 @@ fn ntt4x30_vec_znx_big_normalize_cross<R, A, BE>(
         }
 
         'inner: loop {
-            let res_slice: &mut [i64] = res.at_mut(res_col, res_limb);
+            let res_slice = res.at_mut(res_limb);
             let a_take: usize = a_base2k.min(a_take_left).min(res_acc_left);
 
             if a_take != 0 {
@@ -678,9 +677,9 @@ fn ntt4x30_vec_znx_big_normalize_cross<R, A, BE>(
         let carry_to_use = if a_start == a_end { a_carry } else { res_carry };
         for j in 0..res_end {
             if j == res_end - 1 {
-                BE::nfc_final_step_assign(res_base2k, 0, res.at_mut(res_col, res_end - j - 1), carry_to_use);
+                BE::nfc_final_step_assign(res_base2k, 0, res.at_mut(res_end - j - 1), carry_to_use);
             } else {
-                BE::nfc_middle_step_assign(res_base2k, 0, res.at_mut(res_col, res_end - j - 1), carry_to_use);
+                BE::nfc_middle_step_assign(res_base2k, 0, res.at_mut(res_end - j - 1), carry_to_use);
             }
         }
     }
@@ -1451,10 +1450,117 @@ pub fn ntt4x30_vec_znx_big_normalize<R, A, BE>(
     for<'x> BE::BufMut<'x>: HostDataMut,
     for<'x> BE::BufRef<'x>: HostDataRef,
 {
+    let n = res.to_backend_mut().n();
+    ntt4x30_vec_znx_big_normalize_range(res, res_base2k, res_offset, res_col, a, a_base2k, a_col, 0, n, carry);
+}
+
+/// [`ntt4x30_vec_znx_big_normalize`] restricted to `[coeff_start, coeff_start + coeff_len)`;
+/// `carry` needs `3 * coeff_len` elements private to the range.
+#[allow(clippy::too_many_arguments)]
+fn ntt4x30_vec_znx_big_normalize_range<R, A, BE>(
+    res: &mut R,
+    res_base2k: usize,
+    res_offset: i64,
+    res_col: usize,
+    a: &A,
+    a_base2k: usize,
+    a_col: usize,
+    coeff_start: usize,
+    coeff_len: usize,
+    carry: &mut [i128],
+) where
+    R: VecZnxToBackendMut<BE>,
+    A: VecZnxBigToBackendRef<BE>,
+    BE: Backend<BigWord = i128, ZnxWord = i64> + I128NormalizeOps,
+    for<'x> BE::BufMut<'x>: HostDataMut,
+    for<'x> BE::BufRef<'x>: HostDataRef,
+{
+    #[cfg(debug_assertions)]
+    {
+        assert!(carry.len() >= 3 * coeff_len);
+    }
+    let mut res = res.to_backend_mut();
+    let (n, cols, size) = (res.n(), res.cols(), res.size());
+    let ptr = res.data.as_mut().as_mut_ptr().cast::<i64>();
+    unsafe {
+        ntt4x30_vec_znx_big_normalize_range_raw::<A, BE>(
+            ptr,
+            n,
+            cols,
+            size,
+            res_base2k,
+            res_offset,
+            res_col,
+            a,
+            a_base2k,
+            a_col,
+            coeff_start,
+            coeff_len,
+            carry,
+        )
+    }
+}
+
+/// Normalizes one coefficient range into a raw host output.
+///
+/// # Safety
+///
+/// `res_ptr` must address a valid `n * cols * size` allocation. Any live calls
+/// using the same allocation must write disjoint coefficient ranges.
+#[allow(clippy::too_many_arguments)]
+#[doc(hidden)]
+pub unsafe fn ntt4x30_vec_znx_big_normalize_range_raw<A, BE>(
+    res_ptr: *mut i64,
+    n: usize,
+    cols: usize,
+    size: usize,
+    res_base2k: usize,
+    res_offset: i64,
+    res_col: usize,
+    a: &A,
+    a_base2k: usize,
+    a_col: usize,
+    coeff_start: usize,
+    coeff_len: usize,
+    carry: &mut [i128],
+) where
+    A: VecZnxBigToBackendRef<BE>,
+    BE: Backend<BigWord = i128, ZnxWord = i64> + I128NormalizeOps,
+    for<'x> BE::BufRef<'x>: HostDataRef,
+{
+    #[cfg(debug_assertions)]
+    {
+        assert_eq!(n, a.to_backend_ref().n());
+        assert!(res_col < cols);
+        assert!(coeff_start + coeff_len <= n);
+        assert!(carry.len() >= 3 * coeff_len);
+    }
+    let mut res = unsafe { VecZnxRangeMut::new(res_ptr, n, cols, res_col, coeff_start, coeff_len) };
     if res_base2k == a_base2k {
-        ntt4x30_vec_znx_big_normalize_inter(res_base2k, res, res_offset, res_col, a, a_col, carry);
+        ntt4x30_vec_znx_big_normalize_inter(
+            res_base2k,
+            &mut res,
+            size,
+            res_offset,
+            a,
+            a_col,
+            coeff_start,
+            coeff_len,
+            carry,
+        );
     } else {
-        ntt4x30_vec_znx_big_normalize_cross(res, res_base2k, res_offset, res_col, a, a_base2k, a_col, carry);
+        ntt4x30_vec_znx_big_normalize_cross(
+            &mut res,
+            size,
+            res_base2k,
+            res_offset,
+            a,
+            a_base2k,
+            a_col,
+            coeff_start,
+            coeff_len,
+            carry,
+        );
     }
 }
 

--- a/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_dft.rs
+++ b/poulpy-cpu-ref/src/reference/ntt4x30/vec_znx_dft.rs
@@ -29,13 +29,16 @@ use crate::{
         Backend, HostDataMut, HostDataRef, Module, VecZnxBackendRef, VecZnxBigBackendMut, VecZnxDft, VecZnxDftBackendMut,
         VecZnxDftBackendRef, ZnxView, ZnxViewMut,
     },
-    reference::ntt4x30::{
-        NttAdd, NttAddAssign, NttCopy, NttDFTExecute, NttFromZnx64, NttNegate, NttNegateAssign, NttSub, NttSubAssign,
-        NttSubNegateAssign, NttToZnx128, NttZero,
-        mat_vec::{BbbMeta, BbcMeta},
-        ntt::{NttTable, NttTableInv, intt_ref},
-        primes::{PrimeSetCrt4, Primes30},
-        types::Q120bScalar,
+    reference::{
+        SendPtr,
+        ntt4x30::{
+            NttAdd, NttAddAssign, NttCopy, NttDFTExecute, NttFromZnx64, NttNegate, NttNegateAssign, NttSub, NttSubAssign,
+            NttSubNegateAssign, NttToZnx128, NttZero,
+            mat_vec::{BbbMeta, BbcMeta},
+            ntt::{NttTable, NttTableInv, intt_ref},
+            primes::{PrimeSetCrt4, Primes30},
+            types::Q120bScalar,
+        },
     },
 };
 
@@ -800,5 +803,39 @@ pub fn ntt4x30_vec_znx_dft_automorphism<BE>(
 
     for limb in min_size..res_size {
         BE::ntt_zero(limb_u64_mut::<_, BE>(res, res_col, limb));
+    }
+}
+
+pub fn ntt4x30_vec_znx_dft_automorphism_add<BE, E: poulpy_hal::execution::TaskExecutor>(
+    plan: &NttAutomorphismPlan,
+    res: &mut VecZnxDftBackendMut<'_, BE>,
+    res_col: usize,
+    a: &VecZnxDftBackendRef<'_, BE>,
+    a_col: usize,
+) where
+    BE: Backend<DftWord = Q120bScalar, ZnxWord = i64> + NttAddAssign,
+    for<'x> <BE as Backend>::BufMut<'x>: HostDataMut,
+    for<'x> <BE as Backend>::BufRef<'x>: HostDataRef,
+{
+    let n = res.n();
+    let cols = res.cols();
+    let size = res.size().min(a.size());
+    let res_ptr = SendPtr::new(cast_slice_mut::<_, u64>(res.raw_mut()).as_mut_ptr());
+    let apply = |limb: usize| {
+        let a_limb = limb_u64::<_, BE>(a, a_col, limb);
+        let start = 4 * n * (limb * cols + res_col);
+        let res_limb = unsafe { std::slice::from_raw_parts_mut(res_ptr.get().add(start), 4 * n) };
+        for (i, &source) in plan.perm.iter().enumerate().take(n) {
+            let source = source as usize;
+            let value = &a_limb[4 * source..4 * source + 4];
+            BE::ntt_add_assign(&mut res_limb[4 * i..4 * i + 4], value);
+        }
+    };
+    if E::IS_PARALLEL {
+        E::for_each(size, apply);
+    } else {
+        for limb in 0..size {
+            apply(limb);
+        }
     }
 }

--- a/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
+++ b/poulpy-cpu-ref/src/reference/vec_znx/normalize.rs
@@ -1,4 +1,4 @@
-use std::mem::size_of;
+use std::{marker::PhantomData, mem::size_of};
 
 use crate::{
     layouts::{Backend, HostDataMut, HostDataRef, VecZnxBackendMut, VecZnxBackendRef, ZnxView, ZnxViewMut},
@@ -23,6 +23,35 @@ fn alloc_host_vec_znx(n: usize, cols: usize, size: usize) -> crate::layouts::Vec
 
 pub fn vec_znx_normalize_tmp_bytes(n: usize) -> usize {
     3 * n * size_of::<i64>()
+}
+
+pub(crate) struct VecZnxRangeMut<'a> {
+    ptr: *mut i64,
+    n: usize,
+    cols: usize,
+    col: usize,
+    start: usize,
+    len: usize,
+    marker: PhantomData<&'a mut i64>,
+}
+
+impl<'a> VecZnxRangeMut<'a> {
+    pub(crate) unsafe fn new(ptr: *mut i64, n: usize, cols: usize, col: usize, start: usize, len: usize) -> Self {
+        Self {
+            ptr,
+            n,
+            cols,
+            col,
+            start,
+            len,
+            marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn at_mut(&mut self, limb: usize) -> &mut [i64] {
+        let offset = (limb * self.cols + self.col) * self.n + self.start;
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.add(offset), self.len) }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -366,19 +395,153 @@ pub fn vec_znx_normalize<'r, 'a, BE>(
     BE::BufMut<'r>: HostDataMut,
     BE::BufRef<'a>: HostDataRef,
 {
-    match res_base2k == a_base2k {
-        true => vec_znx_normalize_inter_base2k::<BE>(res_base2k, res, res_offset, res_col, a, a_col, carry),
-        false => vec_znx_normalize_cross_base2k::<BE>(res, res_base2k, res_offset, res_col, a, a_base2k, a_col, carry),
-    }
+    let n = res.n();
+    vec_znx_normalize_range::<BE>(res, res_base2k, res_offset, res_col, a, a_base2k, a_col, 0, n, carry)
 }
 
-fn vec_znx_normalize_inter_base2k<'r, 'a, BE>(
-    base2k: usize,
+/// [`vec_znx_normalize`] restricted to `[coeff_start, coeff_start + coeff_len)`;
+/// `carry` needs `3 * coeff_len` elements private to the range.
+#[allow(clippy::too_many_arguments)]
+fn vec_znx_normalize_range<'r, 'a, BE>(
     res: &mut VecZnxBackendMut<'r, BE>,
+    res_base2k: usize,
     res_offset: i64,
     res_col: usize,
     a: &VecZnxBackendRef<'a, BE>,
+    a_base2k: usize,
     a_col: usize,
+    coeff_start: usize,
+    coeff_len: usize,
+    carry: &mut [i64],
+) where
+    BE: Backend<ZnxWord = i64>
+        + ZnxZero
+        + ZnxCopy
+        + ZnxAddAssign
+        + ZnxMulPowerOfTwoAssign
+        + ZnxNormalizeFirstStepCarryOnly
+        + ZnxNormalizeMiddleStepCarryOnly
+        + ZnxNormalizeMiddleStep
+        + ZnxNormalizeFinalStep
+        + ZnxNormalizeFirstStep
+        + ZnxExtractDigitAddMul
+        + ZnxNormalizeMiddleStepAssign
+        + ZnxNormalizeFinalStepAssign
+        + ZnxNormalizeDigit,
+    BE::BufMut<'r>: HostDataMut,
+    BE::BufRef<'a>: HostDataRef,
+{
+    #[cfg(debug_assertions)]
+    {
+        assert_eq!(res.n(), a.n());
+        assert!(coeff_start + coeff_len <= res.n());
+        assert!(carry.len() >= 3 * coeff_len);
+    }
+    let (n, cols, size) = (res.n(), res.cols(), res.size());
+    let ptr = res.data.as_mut().as_mut_ptr().cast::<i64>();
+    unsafe {
+        vec_znx_normalize_range_raw::<BE>(
+            ptr,
+            n,
+            cols,
+            size,
+            res_base2k,
+            res_offset,
+            res_col,
+            a,
+            a_base2k,
+            a_col,
+            coeff_start,
+            coeff_len,
+            carry,
+        )
+    }
+}
+
+/// Normalizes one coefficient range into a raw host output.
+///
+/// # Safety
+///
+/// `res_ptr` must address a valid `n * cols * size` allocation. Any live calls
+/// using the same allocation must write disjoint coefficient ranges.
+#[allow(clippy::too_many_arguments)]
+#[doc(hidden)]
+pub unsafe fn vec_znx_normalize_range_raw<'a, BE>(
+    res_ptr: *mut i64,
+    n: usize,
+    cols: usize,
+    size: usize,
+    res_base2k: usize,
+    res_offset: i64,
+    res_col: usize,
+    a: &VecZnxBackendRef<'a, BE>,
+    a_base2k: usize,
+    a_col: usize,
+    coeff_start: usize,
+    coeff_len: usize,
+    carry: &mut [i64],
+) where
+    BE: Backend<ZnxWord = i64>
+        + ZnxZero
+        + ZnxCopy
+        + ZnxAddAssign
+        + ZnxMulPowerOfTwoAssign
+        + ZnxNormalizeFirstStepCarryOnly
+        + ZnxNormalizeMiddleStepCarryOnly
+        + ZnxNormalizeMiddleStep
+        + ZnxNormalizeFinalStep
+        + ZnxNormalizeFirstStep
+        + ZnxExtractDigitAddMul
+        + ZnxNormalizeMiddleStepAssign
+        + ZnxNormalizeFinalStepAssign
+        + ZnxNormalizeDigit,
+    BE::BufRef<'a>: HostDataRef,
+{
+    #[cfg(debug_assertions)]
+    {
+        assert_eq!(n, a.n());
+        assert!(res_col < cols);
+        assert!(coeff_start + coeff_len <= n);
+        assert!(carry.len() >= 3 * coeff_len);
+    }
+    let mut res = unsafe { VecZnxRangeMut::new(res_ptr, n, cols, res_col, coeff_start, coeff_len) };
+    match res_base2k == a_base2k {
+        true => vec_znx_normalize_inter_base2k::<BE>(
+            res_base2k,
+            &mut res,
+            size,
+            res_offset,
+            a,
+            a_col,
+            coeff_start,
+            coeff_len,
+            carry,
+        ),
+        false => vec_znx_normalize_cross_base2k::<BE>(
+            &mut res,
+            size,
+            res_base2k,
+            res_offset,
+            a,
+            a_base2k,
+            a_col,
+            coeff_start,
+            coeff_len,
+            carry,
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn vec_znx_normalize_inter_base2k<'r, 'a, BE>(
+    base2k: usize,
+    res: &mut VecZnxRangeMut<'r>,
+    res_size: usize,
+    res_offset: i64,
+    a: &VecZnxBackendRef<'a, BE>,
+    a_col: usize,
+    coeff_start: usize,
+    coeff_len: usize,
     carry: &mut [i64],
 ) where
     BE: Backend<ZnxWord = i64>
@@ -388,20 +551,12 @@ fn vec_znx_normalize_inter_base2k<'r, 'a, BE>(
         + ZnxNormalizeMiddleStep
         + ZnxNormalizeFinalStepAssign
         + ZnxNormalizeMiddleStepAssign,
-    BE::BufMut<'r>: HostDataMut,
     BE::BufRef<'a>: HostDataRef,
 {
-    #[cfg(debug_assertions)]
-    {
-        assert!(carry.len() >= vec_znx_normalize_tmp_bytes(res.n()) / size_of::<i64>());
-        assert_eq!(res.n(), a.n());
-    }
-
-    let n: usize = res.n();
-    let res_size: usize = res.size();
+    let (lo, hi) = (coeff_start, coeff_start + coeff_len);
     let a_size: usize = a.size();
 
-    let (carry, _) = carry.split_at_mut(n);
+    let (carry, _) = carry.split_at_mut(coeff_len);
 
     let mut lsh: i64 = res_offset % base2k as i64;
     let mut limbs_offset: i64 = res_offset / base2k as i64;
@@ -426,9 +581,9 @@ fn vec_znx_normalize_inter_base2k<'r, 'a, BE>(
     // Computes the carry over the discarded limbs of a
     for j in 0..a_out_range {
         if j == 0 {
-            BE::znx_normalize_first_step_carry_only(base2k, lsh_pos, a.at(a_col, a_size - j - 1), carry);
+            BE::znx_normalize_first_step_carry_only(base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], carry);
         } else {
-            BE::znx_normalize_middle_step_carry_only(base2k, lsh_pos, a.at(a_col, a_size - j - 1), carry);
+            BE::znx_normalize_middle_step_carry_only(base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], carry);
         }
     }
 
@@ -439,7 +594,7 @@ fn vec_znx_normalize_inter_base2k<'r, 'a, BE>(
 
     // Zeroes bottom limbs that will not be interacted with
     for j in res_start..res_size {
-        BE::znx_zero(res.at_mut(res_col, j));
+        BE::znx_zero(res.at_mut(j));
     }
 
     let mid_range: usize = a_start.saturating_sub(a_end);
@@ -449,32 +604,34 @@ fn vec_znx_normalize_inter_base2k<'r, 'a, BE>(
         BE::znx_normalize_middle_step::<true>(
             base2k,
             lsh_pos,
-            res.at_mut(res_col, res_start - j - 1),
-            a.at(a_col, a_start - j - 1),
+            res.at_mut(res_start - j - 1),
+            &a.at(a_col, a_start - j - 1)[lo..hi],
             carry,
         );
     }
 
     // Propagates the carry over the non-overlapping limbs between res and a
     for j in 0..res_end {
-        BE::znx_zero(res.at_mut(res_col, res_end - j - 1));
+        BE::znx_zero(res.at_mut(res_end - j - 1));
         if j == res_end - 1 {
-            BE::znx_normalize_final_step_assign(base2k, lsh_pos, res.at_mut(res_col, res_end - j - 1), carry);
+            BE::znx_normalize_final_step_assign(base2k, lsh_pos, res.at_mut(res_end - j - 1), carry);
         } else {
-            BE::znx_normalize_middle_step_assign(base2k, lsh_pos, res.at_mut(res_col, res_end - j - 1), carry);
+            BE::znx_normalize_middle_step_assign(base2k, lsh_pos, res.at_mut(res_end - j - 1), carry);
         }
     }
 }
 
 #[allow(clippy::too_many_arguments)]
 fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
-    res: &mut VecZnxBackendMut<'r, BE>,
+    res: &mut VecZnxRangeMut<'r>,
+    res_size: usize,
     res_base2k: usize,
     res_offset: i64,
-    res_col: usize,
     a: &VecZnxBackendRef<'a, BE>,
     a_base2k: usize,
     a_col: usize,
+    coeff_start: usize,
+    coeff_len: usize,
     carry: &mut [i64],
 ) where
     BE: Backend<ZnxWord = i64>
@@ -491,21 +648,13 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
         + ZnxNormalizeMiddleStepAssign
         + ZnxNormalizeFinalStepAssign
         + ZnxNormalizeDigit,
-    BE::BufMut<'r>: HostDataMut,
     BE::BufRef<'a>: HostDataRef,
 {
-    #[cfg(debug_assertions)]
-    {
-        assert!(carry.len() >= vec_znx_normalize_tmp_bytes(res.n()) / size_of::<i64>());
-        assert_eq!(res.n(), a.n());
-    }
-
-    let n: usize = res.n();
-    let res_size: usize = res.size();
+    let (lo, hi) = (coeff_start, coeff_start + coeff_len);
     let a_size: usize = a.size();
 
-    let (a_norm, carry) = carry.split_at_mut(n);
-    let (res_carry, a_carry) = carry[..2 * n].split_at_mut(n);
+    let (a_norm, carry) = carry.split_at_mut(coeff_len);
+    let (res_carry, a_carry) = carry[..2 * coeff_len].split_at_mut(coeff_len);
     BE::znx_zero(res_carry);
 
     // Total precision (in bits) that `a` and `res` can represent.
@@ -542,7 +691,7 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
     // need to ensure that the limbs starting from `res_end`
     // are zero.
     for j in 0..res_size {
-        BE::znx_zero(res.at_mut(res_col, j));
+        BE::znx_zero(res.at_mut(j));
     }
 
     // Case where offset is positive and greater or equal
@@ -556,9 +705,9 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
 
     for j in 0..a_out_range {
         if j == 0 {
-            BE::znx_normalize_first_step_carry_only(a_base2k, lsh_pos, a.at(a_col, a_size - j - 1), a_carry);
+            BE::znx_normalize_first_step_carry_only(a_base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], a_carry);
         } else {
-            BE::znx_normalize_middle_step_carry_only(a_base2k, lsh_pos, a.at(a_col, a_size - j - 1), a_carry);
+            BE::znx_normalize_middle_step_carry_only(a_base2k, lsh_pos, &a.at(a_col, a_size - j - 1)[lo..hi], a_carry);
         }
     }
 
@@ -581,7 +730,7 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
         let a_limb: usize = a_start - j - 1;
 
         // Current res & a limbs
-        let a_slice: &[i64] = a.at(a_col, a_limb);
+        let a_slice: &[i64] = &a.at(a_col, a_limb)[lo..hi];
 
         // Trackers: wow much of a_norm is left to
         // be flushed on res.
@@ -620,7 +769,7 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
         // extracted.
         'inner: loop {
             // Current limb of res
-            let res_slice: &mut [i64] = res.at_mut(res_col, res_limb);
+            let res_slice = res.at_mut(res_limb);
 
             // We can take at most a_base2k bits
             // but not more than what is left on a_norm or what is left to
@@ -713,9 +862,9 @@ fn vec_znx_normalize_cross_base2k<'r, 'a, BE>(
 
         for j in 0..res_end {
             if j == res_end - 1 {
-                BE::znx_normalize_final_step_assign(res_base2k, 0, res.at_mut(res_col, res_end - j - 1), carry_to_use);
+                BE::znx_normalize_final_step_assign(res_base2k, 0, res.at_mut(res_end - j - 1), carry_to_use);
             } else {
-                BE::znx_normalize_middle_step_assign(res_base2k, 0, res.at_mut(res_col, res_end - j - 1), carry_to_use);
+                BE::znx_normalize_middle_step_assign(res_base2k, 0, res.at_mut(res_end - j - 1), carry_to_use);
             }
         }
     }
@@ -726,20 +875,69 @@ where
     BE: Backend<ZnxWord = i64> + ZnxNormalizeFirstStepAssign + ZnxNormalizeMiddleStepAssign + ZnxNormalizeFinalStepAssign,
     BE::BufMut<'r>: HostDataMut,
 {
+    let n = res.n();
+    vec_znx_normalize_assign_range::<BE>(base2k, res, res_col, 0, n, carry)
+}
+
+/// [`vec_znx_normalize_assign`] restricted to `[coeff_start, coeff_start + coeff_len)`.
+fn vec_znx_normalize_assign_range<'r, BE>(
+    base2k: usize,
+    res: &mut VecZnxBackendMut<'r, BE>,
+    res_col: usize,
+    coeff_start: usize,
+    coeff_len: usize,
+    carry: &mut [i64],
+) where
+    BE: Backend<ZnxWord = i64> + ZnxNormalizeFirstStepAssign + ZnxNormalizeMiddleStepAssign + ZnxNormalizeFinalStepAssign,
+    BE::BufMut<'r>: HostDataMut,
+{
     #[cfg(debug_assertions)]
     {
-        assert!(carry.len() >= res.n());
+        assert!(coeff_start + coeff_len <= res.n());
+        assert!(carry.len() >= coeff_len);
     }
 
-    let res_size: usize = res.size();
+    let (n, cols, size) = (res.n(), res.cols(), res.size());
+    let ptr = res.data.as_mut().as_mut_ptr().cast::<i64>();
+    unsafe { vec_znx_normalize_assign_range_raw::<BE>(ptr, n, cols, size, base2k, res_col, coeff_start, coeff_len, carry) }
+}
 
-    for j in (0..res_size).rev() {
-        if j == res_size - 1 {
-            BE::znx_normalize_first_step_assign(base2k, 0, res.at_mut(res_col, j), carry);
+/// Normalizes one coefficient range in a raw host output.
+///
+/// # Safety
+///
+/// `res_ptr` must address a valid `n * cols * size` allocation. Any live calls
+/// using the same allocation must write disjoint coefficient ranges.
+#[allow(clippy::too_many_arguments)]
+#[doc(hidden)]
+pub unsafe fn vec_znx_normalize_assign_range_raw<BE>(
+    res_ptr: *mut i64,
+    n: usize,
+    cols: usize,
+    size: usize,
+    base2k: usize,
+    res_col: usize,
+    coeff_start: usize,
+    coeff_len: usize,
+    carry: &mut [i64],
+) where
+    BE: Backend<ZnxWord = i64> + ZnxNormalizeFirstStepAssign + ZnxNormalizeMiddleStepAssign + ZnxNormalizeFinalStepAssign,
+{
+    #[cfg(debug_assertions)]
+    {
+        assert!(res_col < cols);
+        assert!(coeff_start + coeff_len <= n);
+        assert!(carry.len() >= coeff_len);
+    }
+    let mut res = unsafe { VecZnxRangeMut::new(res_ptr, n, cols, res_col, coeff_start, coeff_len) };
+    let carry = &mut carry[..coeff_len];
+    for j in (0..size).rev() {
+        if j == size - 1 {
+            BE::znx_normalize_first_step_assign(base2k, 0, res.at_mut(j), carry);
         } else if j == 0 {
-            BE::znx_normalize_final_step_assign(base2k, 0, res.at_mut(res_col, j), carry);
+            BE::znx_normalize_final_step_assign(base2k, 0, res.at_mut(j), carry);
         } else {
-            BE::znx_normalize_middle_step_assign(base2k, 0, res.at_mut(res_col, j), carry);
+            BE::znx_normalize_middle_step_assign(base2k, 0, res.at_mut(j), carry);
         }
     }
 }
@@ -813,7 +1011,7 @@ fn test_vec_znx_normalize_cross_base2k() {
 
                 let mut have: VecZnx<Vec<u8>, i64> = alloc_host_vec_znx(n, 1, out_size);
                 have.fill_uniform(60, &mut source);
-                vec_znx_normalize_cross_base2k::<FFT64Ref>(
+                vec_znx_normalize::<FFT64Ref>(
                     &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut have),
                     out_base2k,
                     offset,
@@ -922,12 +1120,13 @@ fn test_vec_znx_normalize_inter_base2k() {
             // Fills "have" with the shifted normalization of "want"
             let mut have: VecZnx<Vec<u8>, i64> = alloc_host_vec_znx(n, 1, size);
             have.fill_uniform(60, &mut source);
-            vec_znx_normalize_inter_base2k::<FFT64Ref>(
-                base2k,
+            vec_znx_normalize::<FFT64Ref>(
                 &mut <VecZnx<Vec<u8>, i64> as VecZnxToBackendMut<FFT64Ref>>::to_backend_mut(&mut have),
+                base2k,
                 offset,
                 0,
                 &<VecZnx<Vec<u8>, i64> as VecZnxToBackendRef<FFT64Ref>>::to_backend_ref(&want),
+                base2k,
                 0,
                 &mut carry,
             );

--- a/poulpy-cpu-ref/src/tests.rs
+++ b/poulpy-cpu-ref/src/tests.rs
@@ -6,7 +6,7 @@ use poulpy_hal::{
     layouts::Module,
     test_suite::convolution::{
         test_convolution, test_convolution_accumulate, test_convolution_accumulate_fused, test_convolution_by_const,
-        test_convolution_pairwise,
+        test_convolution_by_const_add, test_convolution_pairwise,
     },
 };
 
@@ -21,6 +21,7 @@ mod delegating_backend;
 fn test_convolution_by_const_fft64_ref() {
     let module: Module<FFT64Ref> = Module::<FFT64Ref>::new(8);
     test_convolution_by_const(&module, 17);
+    test_convolution_by_const_add(&module, 17);
 }
 
 #[test]
@@ -51,6 +52,7 @@ fn test_convolution_accumulate_fused_fft64_ref() {
 fn test_convolution_by_const_ntt4x30_ref() {
     let module: Module<NTT4x30Ref> = Module::<NTT4x30Ref>::new(8);
     test_convolution_by_const(&module, 50);
+    test_convolution_by_const_add(&module, 50);
 }
 
 #[test]
@@ -192,6 +194,8 @@ cross_backend_test_suite! {
     params = TestParams { size: 1<<8, base2k: 12 },
     tests = {
         test_vec_znx_dft_automorphism => poulpy_hal::test_suite::vec_znx_dft::test_vec_znx_dft_automorphism,
+        test_vec_znx_dft_automorphism_add => poulpy_hal::test_suite::vec_znx_dft::test_vec_znx_dft_automorphism_add,
+        test_vec_znx_idft_normalize_consume => poulpy_hal::test_suite::vec_znx_dft::test_vec_znx_idft_normalize_consume,
     }
 }
 cross_backend_test_suite! {

--- a/poulpy-hal/src/api/convolution.rs
+++ b/poulpy-hal/src/api/convolution.rs
@@ -78,6 +78,22 @@ pub trait Convolution<BE: Backend> {
         scratch: &mut ScratchArena<'_, BE>,
     );
 
+    /// `res[res_col] +=` the [`Convolution::cnv_by_const_apply`] result; limbs
+    /// the convolution would zero-fill are left untouched.
+    #[allow(clippy::too_many_arguments)]
+    fn cnv_by_const_apply_add(
+        &self,
+        cnv_offset: usize,
+        res: &mut VecZnxBigBackendMut<'_, BE>,
+        res_col: usize,
+        a: &VecZnxBackendRef<'_, BE>,
+        a_col: usize,
+        b: &VecZnxBackendRef<'_, BE>,
+        b_col: usize,
+        b_coeff: usize,
+        scratch: &mut ScratchArena<'_, BE>,
+    );
+
     #[allow(clippy::too_many_arguments)]
     /// Evaluates a bivariate convolution over Z\[X, Y\] (x) Z\[X, Y\] mod (X^N + 1) where Y = 2^-K over the
     /// selected columns and stores the result on the selected column, scaled by 2^{cnv_offset * Base2K}

--- a/poulpy-hal/src/api/vec_znx_dft.rs
+++ b/poulpy-hal/src/api/vec_znx_dft.rs
@@ -1,5 +1,6 @@
 use crate::layouts::{
-    Backend, ScratchArena, VecZnxBackendRef, VecZnxBigBackendMut, VecZnxDftBackendMut, VecZnxDftBackendRef, VecZnxDftOwned,
+    Backend, ScratchArena, VecZnxBackendMut, VecZnxBackendRef, VecZnxBigBackendMut, VecZnxDftBackendMut, VecZnxDftBackendRef,
+    VecZnxDftOwned,
 };
 
 /// Allocates a [`VecZnxDft`](crate::layouts::VecZnxDft).
@@ -60,6 +61,28 @@ pub trait VecZnxIdftApplyTmpA<B: Backend> {
         res_col: usize,
         a: &mut VecZnxDftBackendMut<'_, B>,
         a_col: usize,
+    );
+}
+
+/// Returns scratch bytes required for [`VecZnxIdftNormalizeConsume`].
+pub trait VecZnxIdftNormalizeConsumeTmpBytes {
+    fn vec_znx_idft_normalize_consume_tmp_bytes(&self, res_size: usize, a_size: usize) -> usize;
+}
+
+/// Inverse DFT fused with normalization: `res[res_col] = normalize(idft(a[a_col]) + addend)`,
+/// clobbering `a[a_col]`.
+pub trait VecZnxIdftNormalizeConsume<B: Backend> {
+    #[allow(clippy::too_many_arguments)]
+    fn vec_znx_idft_normalize_consume(
+        &self,
+        res: &mut VecZnxBackendMut<'_, B>,
+        res_base2k: usize,
+        res_col: usize,
+        a: &mut VecZnxDftBackendMut<'_, B>,
+        a_col: usize,
+        a_base2k: usize,
+        addend: Option<(&VecZnxBackendRef<'_, B>, usize)>,
+        scratch: &mut ScratchArena<'_, B>,
     );
 }
 
@@ -175,6 +198,17 @@ pub trait VecZnxDftAutomorphismPlan<B: Backend> {
 /// result into `res` (out-of-place).
 pub trait VecZnxDftAutomorphism<B: Backend>: VecZnxDftAutomorphismPlan<B> {
     fn vec_znx_dft_automorphism_with_plan(
+        &self,
+        plan: &Self::Plan,
+        res: &mut VecZnxDftBackendMut<'_, B>,
+        res_col: usize,
+        a: &VecZnxDftBackendRef<'_, B>,
+        a_col: usize,
+    );
+
+    /// `res[res_col] += automorphism(a[a_col])` over `min(res.size(), a.size())` limbs.
+    #[allow(clippy::too_many_arguments)]
+    fn vec_znx_dft_automorphism_add_with_plan(
         &self,
         plan: &Self::Plan,
         res: &mut VecZnxDftBackendMut<'_, B>,

--- a/poulpy-hal/src/delegates/convolution.rs
+++ b/poulpy-hal/src/delegates/convolution.rs
@@ -67,8 +67,8 @@ impl_convolution_delegate!(
     fn cnv_apply_dft_tmp_bytes(&self, cnv_offset: usize, res_size: usize, a_size: usize, b_size: usize) -> usize {
         <BE as HalConvolutionImpl<BE>>::cnv_apply_dft_tmp_bytes(self, cnv_offset, res_size, a_size, b_size)
     },
-    fn cnv_by_const_apply_tmp_bytes(&self, res_size: usize, cnv_offset: usize, a_size: usize, b_size: usize) -> usize {
-        <BE as HalConvolutionImpl<BE>>::cnv_by_const_apply_tmp_bytes(self, res_size, cnv_offset, a_size, b_size)
+    fn cnv_by_const_apply_tmp_bytes(&self, cnv_offset: usize, res_size: usize, a_size: usize, b_size: usize) -> usize {
+        <BE as HalConvolutionImpl<BE>>::cnv_by_const_apply_tmp_bytes(self, cnv_offset, res_size, a_size, b_size)
     },
     fn cnv_by_const_apply(
         &self,
@@ -83,6 +83,22 @@ impl_convolution_delegate!(
         scratch: &mut ScratchArena<'_, BE>,
     ) {
         <BE as HalConvolutionImpl<BE>>::cnv_by_const_apply(self, cnv_offset, res, res_col, a, a_col, b, b_col, b_coeff, scratch)
+    },
+    fn cnv_by_const_apply_add(
+        &self,
+        cnv_offset: usize,
+        res: &mut VecZnxBigBackendMut<'_, BE>,
+        res_col: usize,
+        a: &VecZnxBackendRef<'_, BE>,
+        a_col: usize,
+        b: &VecZnxBackendRef<'_, BE>,
+        b_col: usize,
+        b_coeff: usize,
+        scratch: &mut ScratchArena<'_, BE>,
+    ) {
+        <BE as HalConvolutionImpl<BE>>::cnv_by_const_apply_add(
+            self, cnv_offset, res, res_col, a, a_col, b, b_col, b_coeff, scratch,
+        )
     },
     fn cnv_apply_dft(
         &self,

--- a/poulpy-hal/src/delegates/vec_znx_dft.rs
+++ b/poulpy-hal/src/delegates/vec_znx_dft.rs
@@ -3,10 +3,11 @@ use crate::{
         VecZnxDftAddAssign, VecZnxDftAddInto, VecZnxDftAddScaledAssign, VecZnxDftAlloc, VecZnxDftApply, VecZnxDftAutomorphism,
         VecZnxDftAutomorphismPlan, VecZnxDftBytesOf, VecZnxDftCopy, VecZnxDftFromBytes, VecZnxDftSub, VecZnxDftSubAssign,
         VecZnxDftSubNegateAssign, VecZnxDftZero, VecZnxIdftApply, VecZnxIdftApplyTmpA, VecZnxIdftApplyTmpBytes,
+        VecZnxIdftNormalizeConsume, VecZnxIdftNormalizeConsumeTmpBytes,
     },
     layouts::{
-        Backend, Module, ScratchArena, VecZnxBackendRef, VecZnxBigBackendMut, VecZnxDftBackendMut, VecZnxDftBackendRef,
-        VecZnxDftOwned,
+        Backend, Module, ScratchArena, VecZnxBackendMut, VecZnxBackendRef, VecZnxBigBackendMut, VecZnxDftBackendMut,
+        VecZnxDftBackendRef, VecZnxDftOwned,
     },
     oep::HalVecZnxDftImpl,
 };
@@ -58,6 +59,30 @@ impl_vec_znx_dft_delegate!(
         scratch: &mut ScratchArena<'_, B>,
     ) {
         B::vec_znx_idft_apply(self, res, res_col, a, a_col, scratch)
+    }
+);
+
+impl_vec_znx_dft_delegate!(
+    VecZnxIdftNormalizeConsumeTmpBytes,
+    fn vec_znx_idft_normalize_consume_tmp_bytes(&self, res_size: usize, a_size: usize) -> usize {
+        B::vec_znx_idft_normalize_consume_tmp_bytes(self, res_size, a_size)
+    }
+);
+
+impl_vec_znx_dft_delegate!(
+    VecZnxIdftNormalizeConsume<B>,
+    fn vec_znx_idft_normalize_consume(
+        &self,
+        res: &mut VecZnxBackendMut<'_, B>,
+        res_base2k: usize,
+        res_col: usize,
+        a: &mut VecZnxDftBackendMut<'_, B>,
+        a_col: usize,
+        a_base2k: usize,
+        addend: Option<(&VecZnxBackendRef<'_, B>, usize)>,
+        scratch: &mut ScratchArena<'_, B>,
+    ) {
+        B::vec_znx_idft_normalize_consume(self, res, res_base2k, res_col, a, a_col, a_base2k, addend, scratch);
     }
 );
 
@@ -218,5 +243,16 @@ where
         a_col: usize,
     ) {
         B::vec_znx_dft_automorphism_with_plan(self, plan, res, res_col, a, a_col);
+    }
+
+    fn vec_znx_dft_automorphism_add_with_plan(
+        &self,
+        plan: &Self::Plan,
+        res: &mut VecZnxDftBackendMut<'_, B>,
+        res_col: usize,
+        a: &VecZnxDftBackendRef<'_, B>,
+        a_col: usize,
+    ) {
+        B::vec_znx_dft_automorphism_add_with_plan(self, plan, res, res_col, a, a_col);
     }
 }

--- a/poulpy-hal/src/execution.rs
+++ b/poulpy-hal/src/execution.rs
@@ -1,0 +1,197 @@
+//! Backend-selected task execution.
+
+use crate::layouts::{Backend, ScratchArena};
+
+pub trait TaskExecutor: Send + Sync + 'static {
+    const IS_PARALLEL: bool;
+
+    fn is_parallel() -> bool {
+        Self::IS_PARALLEL
+    }
+
+    /// Tasks this executor can run concurrently: the pool width, or one when serial.
+    fn max_parallelism() -> usize {
+        1
+    }
+
+    fn join<A, B, RA, RB>(left: A, right: B) -> (RA, RB)
+    where
+        A: FnOnce() -> RA + Send,
+        B: FnOnce() -> RB + Send,
+        RA: Send,
+        RB: Send;
+
+    fn for_each<F>(count: usize, task: F)
+    where
+        F: Fn(usize) + Send + Sync,
+    {
+        for index in 0..count {
+            task(index);
+        }
+    }
+
+    /// Applies `task` to every index, over `per_worker`-sized slices of `scratch`.
+    fn for_each_chunked<T, F>(count: usize, scratch: &mut [T], per_worker: usize, task: F)
+    where
+        T: Send,
+        F: Fn(&mut [T], usize) + Send + Sync,
+    {
+        assert!(
+            scratch.len() >= per_worker,
+            "worker scratch: {} < per_worker {per_worker}",
+            scratch.len()
+        );
+        let worker = &mut scratch[..per_worker];
+        for index in 0..count {
+            task(worker, index);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SerialTaskExecutor;
+
+impl TaskExecutor for SerialTaskExecutor {
+    const IS_PARALLEL: bool = false;
+
+    fn join<A, B, RA, RB>(left: A, right: B) -> (RA, RB)
+    where
+        A: FnOnce() -> RA + Send,
+        B: FnOnce() -> RB + Send,
+        RA: Send,
+        RB: Send,
+    {
+        (left(), right())
+    }
+}
+
+/// Number of concurrent workers for `tasks` independent tasks.
+pub fn worker_count<E: TaskExecutor>(requested: usize, tasks: usize) -> usize {
+    assert!(requested > 0, "parallel worker count must be non-zero");
+    if tasks == 0 {
+        0
+    } else if E::is_parallel() {
+        requested.min(E::max_parallelism()).min(tasks).max(1)
+    } else {
+        1
+    }
+}
+
+/// Worker slices each kernel family is sized for, declared per backend.
+///
+/// The defaults are serial; a backend overrides the families it has measured.
+pub trait ScratchWorkers {
+    /// `cnv_prepare_left`, `cnv_prepare_right`, `cnv_prepare_self`.
+    const PREPARE: usize = 1;
+    /// `cnv_apply_dft`, `cnv_pairwise_apply_dft`, `cnv_accumulate_dft`.
+    const APPLY: usize = 1;
+    /// `vmp_apply_dft_to_dft` and its accumulate and strided variants.
+    const VMP: usize = 1;
+    /// `vec_znx_idft_apply`.
+    const IDFT: usize = 1;
+}
+
+/// Worker slices to size scratch for, given the kernel's [`ScratchWorkers`] cap
+/// min'd with the task count where that is known.
+///
+/// Independent of the pool width, so a reservation cannot change between the
+/// call that sizes it and the call that uses it.
+pub fn scratch_workers<E: TaskExecutor>(cap: usize) -> usize {
+    if E::IS_PARALLEL { cap.max(1) } else { 1 }
+}
+
+/// [`scratch_workers`], bounded by the scratch bytes actually available.
+///
+/// Returns at least one: one worker's scratch is a precondition of every kernel,
+/// and the caller's take reports the shortfall when it does not fit.
+pub fn scratch_workers_within<E: TaskExecutor>(cap: usize, per_worker: usize, available: usize) -> usize {
+    if per_worker == 0 {
+        return 1;
+    }
+    scratch_workers::<E>(cap).min(available / per_worker).max(1)
+}
+
+/// Per-worker scratch size, aligned to the backend's scratch alignment.
+pub fn worker_scratch_bytes<B: Backend>(bytes: usize) -> usize {
+    assert!(B::SCRATCH_ALIGN > 0, "backend scratch alignment must be non-zero");
+    bytes.next_multiple_of(B::SCRATCH_ALIGN)
+}
+
+/// Applies `task` to every item, distributing them over the given arenas.
+pub fn for_each_with_scratch<E, B, T, F>(items: &mut [T], base_index: usize, scratch: Vec<ScratchArena<'_, B>>, task: &F)
+where
+    E: TaskExecutor,
+    B: Backend,
+    T: Send,
+    F: Fn(usize, &mut T, &mut ScratchArena<'_, B>) + Send + Sync,
+{
+    assert!(!items.is_empty());
+    assert!(!scratch.is_empty());
+    assert!(scratch.len() <= items.len());
+
+    if scratch.len() == 1 {
+        let mut scratch = scratch.into_iter().next().unwrap();
+        for (offset, item) in items.iter_mut().enumerate() {
+            task(base_index + offset, item, &mut scratch);
+        }
+        return;
+    }
+
+    let left_workers = scratch.len() / 2;
+    let split = items.len() * left_workers / scratch.len();
+    let (left_items, right_items) = items.split_at_mut(split);
+    let mut left_scratch = scratch;
+    let right_scratch = left_scratch.split_off(left_workers);
+
+    E::join(
+        || for_each_with_scratch::<E, B, T, F>(left_items, base_index, left_scratch, task),
+        || for_each_with_scratch::<E, B, T, F>(right_items, base_index + split, right_scratch, task),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SerialTaskExecutor, TaskExecutor, scratch_workers, scratch_workers_within, worker_count};
+
+    #[test]
+    fn serial_executor_always_uses_one_worker() {
+        assert!(!SerialTaskExecutor::is_parallel());
+        assert_eq!(worker_count::<SerialTaskExecutor>(8, 32), 1);
+        assert_eq!(worker_count::<SerialTaskExecutor>(8, 0), 0);
+        assert_eq!(scratch_workers::<SerialTaskExecutor>(32), 1);
+        assert_eq!(scratch_workers_within::<SerialTaskExecutor>(32, 64, 4096), 1);
+    }
+
+    #[test]
+    fn scratch_workers_are_bounded_by_the_arena() {
+        assert_eq!(scratch_workers_within::<SerialTaskExecutor>(32, 64, 4096), 1);
+        assert_eq!(scratch_workers_within::<SerialTaskExecutor>(32, 64, 0), 1);
+        assert_eq!(scratch_workers_within::<SerialTaskExecutor>(32, 0, 4096), 1);
+    }
+
+    #[test]
+    fn serial_for_each_chunked_visits_every_index_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let mut scratch = [0usize; 4];
+        let visits: Vec<AtomicUsize> = (0..7).map(|_| AtomicUsize::new(0)).collect();
+        SerialTaskExecutor::for_each_chunked(7, &mut scratch, 4, |worker, i| {
+            assert_eq!(worker.len(), 4);
+            visits[i].fetch_add(1, Ordering::Relaxed);
+        });
+        assert!(visits.iter().all(|v| v.load(Ordering::Relaxed) == 1));
+    }
+
+    #[test]
+    fn for_each_chunked_accepts_zero_tasks() {
+        let mut scratch = [0usize; 4];
+        SerialTaskExecutor::for_each_chunked(0, &mut scratch, 4, |_, _| panic!("no task expected"));
+    }
+
+    #[test]
+    #[should_panic(expected = "worker scratch")]
+    fn for_each_chunked_rejects_undersized_scratch() {
+        let mut scratch = [0usize; 2];
+        SerialTaskExecutor::for_each_chunked(1, &mut scratch, 4, |_, _| {});
+    }
+}

--- a/poulpy-hal/src/layouts/mod.rs
+++ b/poulpy-hal/src/layouts/mod.rs
@@ -137,6 +137,7 @@ where
 pub struct HostBytesBackend;
 
 impl Backend for HostBytesBackend {
+    type TaskExecutor = crate::execution::SerialTaskExecutor;
     type ZnxWord = i64;
     type BigWord = i128;
     type DftWord = i64;
@@ -456,10 +457,13 @@ impl<BE> HostStaged for BE where BE: Backend<ZnxWord = i64, OwnedBuf: CopyToHost
 /// scalar types, and handle representation as a source backend.
 #[macro_export]
 macro_rules! impl_backend_from {
-    ($be:ty, $from:ty) => {
+    (@executor $from:ty, $executor:ty) => { $executor };
+    (@executor $from:ty) => { <$from as poulpy_hal::layouts::Backend>::TaskExecutor };
+    ($be:ty, $from:ty $(, $executor:ty)?) => {
         impl poulpy_hal::layouts::Backend for $be {
             const DFT_IS_EXACT: bool = <$from as poulpy_hal::layouts::Backend>::DFT_IS_EXACT;
 
+            type TaskExecutor = poulpy_hal::impl_backend_from!(@executor $from $(, $executor)?);
             type ZnxWord = <$from as poulpy_hal::layouts::Backend>::ZnxWord;
             type BigWord = <$from as poulpy_hal::layouts::Backend>::BigWord;
             type DftWord = <$from as poulpy_hal::layouts::Backend>::DftWord;

--- a/poulpy-hal/src/layouts/module.rs
+++ b/poulpy-hal/src/layouts/module.rs
@@ -26,6 +26,8 @@ pub trait Backend: Sized + Sync + Send + PartialEq + Eq {
     /// the [`DftWord`](crate::layouts::DftWord) byte-layout marker.
     const DFT_IS_EXACT: bool = false;
 
+    /// Task executor selected by this backend.
+    type TaskExecutor: crate::execution::TaskExecutor;
     /// Word type for coefficient-domain (small) polynomial representations.
     type ZnxWord: crate::layouts::ZnxWord;
     /// Word type for extended-precision (big) polynomial representations.

--- a/poulpy-hal/src/layouts/scratch.rs
+++ b/poulpy-hal/src/layouts/scratch.rs
@@ -28,6 +28,9 @@ pub struct ScratchArena<'a, B: Backend> {
     _phantom: PhantomData<&'a mut B::OwnedBuf>,
 }
 
+// Moving an arena transfers exclusive access to its disjoint byte range.
+unsafe impl<B: Backend> Send for ScratchArena<'_, B> where B::OwnedBuf: Send {}
+
 impl<B: Backend> ScratchOwned<B> {
     /// Borrows this owned scratch buffer as a backend-native arena.
     pub fn arena(&mut self) -> ScratchArena<'_, B> {
@@ -41,6 +44,20 @@ impl<B: Backend> ScratchOwned<B> {
 }
 
 impl<'a, B: Backend> ScratchArena<'a, B> {
+    /// Re-tags this arena for a backend sharing the same owned storage.
+    pub fn into_backend<Other>(self) -> ScratchArena<'a, Other>
+    where
+        Other: Backend<OwnedBuf = B::OwnedBuf>,
+    {
+        assert_eq!(B::SCRATCH_ALIGN, Other::SCRATCH_ALIGN);
+        ScratchArena {
+            data: self.data,
+            start: self.start,
+            end: self.end,
+            _phantom: PhantomData,
+        }
+    }
+
     /// Reborrows this arena with a shorter lifetime.
     pub fn borrow<'b>(&'b mut self) -> ScratchArena<'b, B> {
         ScratchArena {

--- a/poulpy-hal/src/lib.rs
+++ b/poulpy-hal/src/lib.rs
@@ -105,6 +105,9 @@ pub mod api;
 /// the safe API layer to the unsafe backend implementations.
 pub mod delegates;
 
+/// Backend-selected task execution policies.
+pub mod execution;
+
 /// Backend-agnostic data layout types for polynomials, vectors, matrices,
 /// and prepared (DFT-domain) representations.
 ///

--- a/poulpy-hal/src/oep/hal_impl.rs
+++ b/poulpy-hal/src/oep/hal_impl.rs
@@ -837,6 +837,22 @@ pub unsafe trait HalVecZnxDftImpl<BE: Backend>: Backend {
         a_col: usize,
     );
 
+    fn vec_znx_idft_normalize_consume_tmp_bytes(module: &Module<BE>, res_size: usize, a_size: usize) -> usize;
+
+    /// `res[res_col] = normalize(idft(a[a_col]) + addend)`, clobbering `a[a_col]`.
+    #[allow(clippy::too_many_arguments)]
+    fn vec_znx_idft_normalize_consume(
+        module: &Module<BE>,
+        res: &mut crate::layouts::VecZnxBackendMut<'_, BE>,
+        res_base2k: usize,
+        res_col: usize,
+        a: &mut crate::layouts::VecZnxDftBackendMut<'_, BE>,
+        a_col: usize,
+        a_base2k: usize,
+        addend: Option<(&crate::layouts::VecZnxBackendRef<'_, BE>, usize)>,
+        scratch: &mut ScratchArena<'_, BE>,
+    );
+
     fn vec_znx_dft_add_into(
         module: &Module<BE>,
         res: &mut crate::layouts::VecZnxDftBackendMut<'_, BE>,
@@ -909,6 +925,17 @@ pub unsafe trait HalVecZnxDftImpl<BE: Backend>: Backend {
     fn vec_znx_dft_automorphism_plan(module: &Module<BE>, p: i64) -> Self::AutomorphismPlan;
 
     fn vec_znx_dft_automorphism_with_plan(
+        module: &Module<BE>,
+        plan: &Self::AutomorphismPlan,
+        res: &mut crate::layouts::VecZnxDftBackendMut<'_, BE>,
+        res_col: usize,
+        a: &crate::layouts::VecZnxDftBackendRef<'_, BE>,
+        a_col: usize,
+    );
+
+    /// `res[res_col] += automorphism(a[a_col])` over `min(res.size(), a.size())` limbs;
+    /// res limbs beyond that are left untouched.
+    fn vec_znx_dft_automorphism_add_with_plan(
         module: &Module<BE>,
         plan: &Self::AutomorphismPlan,
         res: &mut crate::layouts::VecZnxDftBackendMut<'_, BE>,
@@ -1085,6 +1112,22 @@ pub unsafe trait HalConvolutionImpl<BE: Backend>: Backend {
 
     #[allow(clippy::too_many_arguments)]
     fn cnv_by_const_apply(
+        module: &Module<BE>,
+        cnv_offset: usize,
+        res: &mut crate::layouts::VecZnxBigBackendMut<'_, BE>,
+        res_col: usize,
+        a: &crate::layouts::VecZnxBackendRef<'_, BE>,
+        a_col: usize,
+        b: &crate::layouts::VecZnxBackendRef<'_, BE>,
+        b_col: usize,
+        b_coeff: usize,
+        scratch: &mut ScratchArena<'_, BE>,
+    );
+
+    /// `res[res_col] +=` the [`Self::cnv_by_const_apply`] result; limbs the
+    /// convolution would zero-fill are left untouched.
+    #[allow(clippy::too_many_arguments)]
+    fn cnv_by_const_apply_add(
         module: &Module<BE>,
         cnv_offset: usize,
         res: &mut crate::layouts::VecZnxBigBackendMut<'_, BE>,

--- a/poulpy-hal/src/test_suite/convolution.rs
+++ b/poulpy-hal/src/test_suite/convolution.rs
@@ -107,6 +107,118 @@ where
     }
 }
 
+/// Verifies `cnv_by_const_apply_add` against `cnv_by_const_apply` +
+/// `vec_znx_big_add_assign`, including the untouched-limb contract.
+pub fn test_convolution_by_const_add<M, BE: crate::test_suite::TestBackend>(module: &M, base2k: usize)
+where
+    M: ModuleN
+        + Convolution<BE>
+        + VecZnxBigNormalize<BE>
+        + VecZnxBigNormalizeTmpBytes
+        + crate::api::VecZnxBigAddAssign<BE>
+        + VecZnxBigAlloc<BE>,
+    ScratchOwned<BE>: ScratchOwnedAlloc<BE>,
+{
+    let mut source: Source = Source::new([0u8; 32]);
+
+    let a_cols: usize = 2;
+    let a_size: usize = 15;
+    let b_size: usize = 3;
+    let res_size: usize = a_size + b_size;
+
+    let mut a = VecZnx::alloc(module.n(), a_cols, a_size);
+    let mut b = VecZnx::alloc(module.n(), 1, b_size);
+    a.fill_uniform(17, &mut source);
+    b.fill_uniform(base2k, &mut source);
+
+    let a_backend = upload_vec_znx::<BE>(&a);
+    let b_backend = upload_vec_znx::<BE>(&b);
+    let mut acc_have: VecZnxBigOwned<BE> = module.vec_znx_big_alloc(1, res_size);
+    let mut acc_want: VecZnxBigOwned<BE> = module.vec_znx_big_alloc(1, res_size);
+    let mut term: VecZnxBigOwned<BE> = module.vec_znx_big_alloc(1, res_size);
+    let mut scratch: ScratchOwned<BE> = ScratchOwned::alloc(
+        module
+            .cnv_by_const_apply_tmp_bytes(0, res_size, a_size, b_size)
+            .max(module.vec_znx_big_normalize_tmp_bytes()),
+    );
+
+    // `cnv_offset` is a limb count; the tail values are clamped out of range.
+    for base_offset in [0, 1, 2, res_size / 2, res_size - 1] {
+        for add_offset in [0, 1, 2, res_size / 2, res_size - 1, res_size, res_size + 1] {
+            // Fused: apply the first term, accumulate the second in place.
+            module.cnv_by_const_apply(
+                base_offset,
+                &mut acc_have.to_backend_mut(),
+                0,
+                &vec_znx_backend_ref::<BE>(&a_backend),
+                0,
+                &vec_znx_backend_ref::<BE>(&b_backend),
+                0,
+                0,
+                &mut scratch.arena(),
+            );
+            module.cnv_by_const_apply_add(
+                add_offset,
+                &mut acc_have.to_backend_mut(),
+                0,
+                &vec_znx_backend_ref::<BE>(&a_backend),
+                1,
+                &vec_znx_backend_ref::<BE>(&b_backend),
+                0,
+                1,
+                &mut scratch.arena(),
+            );
+
+            // Composition: both terms into separate BIG buffers, then added.
+            module.cnv_by_const_apply(
+                base_offset,
+                &mut acc_want.to_backend_mut(),
+                0,
+                &vec_znx_backend_ref::<BE>(&a_backend),
+                0,
+                &vec_znx_backend_ref::<BE>(&b_backend),
+                0,
+                0,
+                &mut scratch.arena(),
+            );
+            module.cnv_by_const_apply(
+                add_offset,
+                &mut term.to_backend_mut(),
+                0,
+                &vec_znx_backend_ref::<BE>(&a_backend),
+                1,
+                &vec_znx_backend_ref::<BE>(&b_backend),
+                0,
+                1,
+                &mut scratch.arena(),
+            );
+            module.vec_znx_big_add_assign(&mut acc_want.to_backend_mut(), 0, &term.to_backend_ref(), 0);
+
+            let normalized = |big: &VecZnxBigOwned<BE>, scratch: &mut ScratchOwned<BE>| {
+                let res_host_template = VecZnx::alloc(module.n(), 1, res_size);
+                let mut res_backend = upload_vec_znx::<BE>(&res_host_template);
+                module.vec_znx_big_normalize(
+                    &mut vec_znx_backend_mut::<BE>(&mut res_backend),
+                    base2k,
+                    0,
+                    0,
+                    &big.to_backend_ref(),
+                    base2k,
+                    0,
+                    &mut scratch.arena(),
+                );
+                download_vec_znx::<BE>(&res_backend)
+            };
+            let res_have = normalized(&acc_have, &mut scratch);
+            let res_want = normalized(&acc_want, &mut scratch);
+            assert_eq!(
+                res_want, res_have,
+                "cnv_by_const_apply_add != apply + big add for offsets ({base_offset}, {add_offset})"
+            );
+        }
+    }
+}
+
 pub fn test_convolution<M, BE: crate::test_suite::TestBackend>(module: &M, base2k: usize)
 where
     M: ModuleN

--- a/poulpy-hal/src/test_suite/vec_znx_dft.rs
+++ b/poulpy-hal/src/test_suite/vec_znx_dft.rs
@@ -6,10 +6,10 @@ use crate::layouts::VecZnxDftToBackendRef;
 
 use crate::{
     api::{
-        ScratchOwnedAlloc, VecZnxAutomorphismBackend, VecZnxBigAlloc, VecZnxBigNormalize, VecZnxBigNormalizeTmpBytes,
-        VecZnxDftAddAssign, VecZnxDftAddInto, VecZnxDftAlloc, VecZnxDftApply, VecZnxDftAutomorphism, VecZnxDftAutomorphismPlan,
-        VecZnxDftCopy, VecZnxDftSub, VecZnxDftSubAssign, VecZnxDftSubNegateAssign, VecZnxIdftApply, VecZnxIdftApplyTmpA,
-        VecZnxIdftApplyTmpBytes,
+        ScratchOwnedAlloc, VecZnxAutomorphismBackend, VecZnxBigAddSmallAssign, VecZnxBigAlloc, VecZnxBigNormalize,
+        VecZnxBigNormalizeTmpBytes, VecZnxDftAddAssign, VecZnxDftAddInto, VecZnxDftAlloc, VecZnxDftApply, VecZnxDftAutomorphism,
+        VecZnxDftAutomorphismPlan, VecZnxDftCopy, VecZnxDftSub, VecZnxDftSubAssign, VecZnxDftSubNegateAssign, VecZnxIdftApply,
+        VecZnxIdftApplyTmpA, VecZnxIdftApplyTmpBytes, VecZnxIdftNormalizeConsume, VecZnxIdftNormalizeConsumeTmpBytes,
     },
     layouts::{FillUniform, HostBytesBackend, Module, ScratchOwned, VecZnx, VecZnxOwned, VecZnxToBackendMut, VecZnxToBackendRef},
     source::Source,
@@ -751,4 +751,243 @@ pub fn test_vec_znx_dft_automorphism<BR: crate::test_suite::TestBackend, BT: cra
 
     contract_check_one_backend::<BR>(base2k, module_host, module_ref, &mut scratch_ref, cols, p_values);
     contract_check_one_backend::<BT>(base2k, module_host, module_test, &mut scratch_test, cols, p_values);
+}
+
+/// Runs the fused-accumulation check `automorphism_add(res, a) ==
+/// add_assign(res, automorphism(a))` on a single backend, including a `res`
+/// wider than `a` (limbs beyond `a.size()` must stay untouched).
+fn automorphism_add_check_one_backend<BE>(
+    base2k: usize,
+    module_host: &Module<HostBytesBackend>,
+    module: &Module<BE>,
+    scratch: &mut ScratchOwned<BE>,
+    cols: usize,
+    p_values: &[i64],
+) where
+    BE: crate::test_suite::TestBackend,
+    Module<BE>: VecZnxDftAlloc<BE>
+        + VecZnxDftApply<BE>
+        + VecZnxDftAutomorphism<BE>
+        + VecZnxDftAddAssign<BE>
+        + VecZnxBigAlloc<BE>
+        + VecZnxIdftApplyTmpA<BE>
+        + VecZnxBigNormalize<BE>
+        + VecZnxBigNormalizeTmpBytes,
+    ScratchOwned<BE>: ScratchOwnedAlloc<BE>,
+{
+    let mut source = Source::new([1u8; 32]);
+
+    for (a_size, res_size) in [(1, 1), (3, 3), (3, 4), (4, 4)] {
+        let mut a = module_host.vec_znx_alloc(cols, a_size);
+        let mut seed = module_host.vec_znx_alloc(cols, res_size);
+        a.fill_uniform(base2k, &mut source);
+        seed.fill_uniform(base2k, &mut source);
+
+        for &p in p_values {
+            let plan = module.vec_znx_dft_automorphism_plan(p);
+            let a_dft = dft_of_uploaded_vec_znx(module, &a, 1, 0);
+
+            // Fused: res += automorphism(a) in one pass.
+            let mut res_have = dft_of_uploaded_vec_znx(module, &seed, 1, 0);
+            for j in 0..cols {
+                module.vec_znx_dft_automorphism_add_with_plan(
+                    &plan,
+                    &mut res_have.to_backend_mut(),
+                    j,
+                    &a_dft.to_backend_ref(),
+                    j,
+                );
+            }
+
+            // Composition: automorphism into a temporary, then DFT-domain add.
+            let mut res_want = dft_of_uploaded_vec_znx(module, &seed, 1, 0);
+            let mut rot = module.vec_znx_dft_alloc(cols, a_size);
+            for j in 0..cols {
+                module.vec_znx_dft_automorphism_with_plan(&plan, &mut rot.to_backend_mut(), j, &a_dft.to_backend_ref(), j);
+                module.vec_znx_dft_add_assign(&mut res_want.to_backend_mut(), j, &rot.to_backend_ref(), j);
+            }
+
+            let have = idft_tmpa_to_host(module, base2k, &mut res_have, scratch);
+            let want = idft_tmpa_to_host(module, base2k, &mut res_want, scratch);
+            assert_eq!(
+                want, have,
+                "automorphism_add != automorphism + add for p={p}, a_size={a_size}, res_size={res_size}"
+            );
+        }
+    }
+}
+
+/// Verifies `vec_znx_dft_automorphism_add_with_plan` against the composition
+/// of `vec_znx_dft_automorphism_with_plan` and `vec_znx_dft_add_assign`, on
+/// both `module_ref` and `module_test`.
+pub fn test_vec_znx_dft_automorphism_add<BR: crate::test_suite::TestBackend, BT: crate::test_suite::TestBackend>(
+    params: &TestParams,
+    module_host: &Module<HostBytesBackend>,
+    module_ref: &Module<BR>,
+    module_test: &Module<BT>,
+) where
+    Module<BR>: VecZnxDftAlloc<BR>
+        + VecZnxDftApply<BR>
+        + VecZnxDftAutomorphism<BR>
+        + VecZnxDftAddAssign<BR>
+        + VecZnxBigAlloc<BR>
+        + VecZnxIdftApplyTmpA<BR>
+        + VecZnxBigNormalize<BR>
+        + VecZnxBigNormalizeTmpBytes,
+    Module<BT>: VecZnxDftAlloc<BT>
+        + VecZnxDftApply<BT>
+        + VecZnxDftAutomorphism<BT>
+        + VecZnxDftAddAssign<BT>
+        + VecZnxBigAlloc<BT>
+        + VecZnxIdftApplyTmpA<BT>
+        + VecZnxBigNormalize<BT>
+        + VecZnxBigNormalizeTmpBytes,
+    ScratchOwned<BR>: ScratchOwnedAlloc<BR>,
+    ScratchOwned<BT>: ScratchOwnedAlloc<BT>,
+{
+    let base2k = params.base2k;
+    assert_eq!(module_ref.n(), module_test.n());
+    let cols = 2;
+    let mut scratch_ref = ScratchOwned::alloc(module_ref.vec_znx_big_normalize_tmp_bytes());
+    let mut scratch_test = ScratchOwned::alloc(module_test.vec_znx_big_normalize_tmp_bytes());
+
+    let p_values: &[i64] = &[1, 5, 3, 7, -1, -5];
+
+    automorphism_add_check_one_backend::<BR>(base2k, module_host, module_ref, &mut scratch_ref, cols, p_values);
+    automorphism_add_check_one_backend::<BT>(base2k, module_host, module_test, &mut scratch_test, cols, p_values);
+}
+
+/// Runs the fused check `idft_normalize_consume(res, a, addend) ==
+/// normalize(idft(a) + addend)` on a single backend, over size and base2k
+/// combinations and both addend arms.
+fn idft_normalize_consume_check_one_backend<BE>(
+    base2k: usize,
+    module_host: &Module<HostBytesBackend>,
+    module: &Module<BE>,
+    cols: usize,
+) where
+    BE: crate::test_suite::TestBackend,
+    Module<BE>: VecZnxDftAlloc<BE>
+        + VecZnxDftApply<BE>
+        + VecZnxIdftApply<BE>
+        + VecZnxIdftApplyTmpBytes
+        + crate::api::VecZnxIdftNormalizeConsume<BE>
+        + crate::api::VecZnxIdftNormalizeConsumeTmpBytes
+        + crate::api::VecZnxBigAddSmallAssign<BE>
+        + VecZnxBigAlloc<BE>
+        + VecZnxBigNormalize<BE>
+        + VecZnxBigNormalizeTmpBytes,
+    ScratchOwned<BE>: ScratchOwnedAlloc<BE>,
+{
+    let mut source = Source::new([2u8; 32]);
+
+    for (a_size, res_size) in [(1, 1), (4, 4), (4, 3), (3, 4)] {
+        for res_base2k in [base2k, base2k - 2] {
+            for with_addend in [false, true] {
+                let mut a = module_host.vec_znx_alloc(cols, a_size);
+                let mut addend = module_host.vec_znx_alloc(1, a_size);
+                a.fill_uniform(base2k, &mut source);
+                addend.fill_uniform(base2k, &mut source);
+                let addend_backend = upload_vec_znx::<BE>(&addend);
+                let addend_ref = vec_znx_backend_ref::<BE>(&addend_backend);
+
+                let mut scratch: ScratchOwned<BE> = ScratchOwned::alloc(
+                    module
+                        .vec_znx_idft_normalize_consume_tmp_bytes(res_size, a_size)
+                        .max(module.vec_znx_idft_apply_tmp_bytes())
+                        .max(module.vec_znx_big_normalize_tmp_bytes()),
+                );
+
+                for col in 0..cols {
+                    // Fused: res = normalize(idft(a) + addend), clobbering a.
+                    let mut a_dft = dft_of_uploaded_vec_znx(module, &a, 1, 0);
+                    let res_host_template = VecZnx::alloc(module.n(), 1, res_size);
+                    let mut res_have_backend = upload_vec_znx::<BE>(&res_host_template);
+                    module.vec_znx_idft_normalize_consume(
+                        &mut vec_znx_backend_mut::<BE>(&mut res_have_backend),
+                        res_base2k,
+                        0,
+                        &mut a_dft.to_backend_mut(),
+                        col,
+                        base2k,
+                        with_addend.then_some((&addend_ref, 0)),
+                        &mut scratch.arena(),
+                    );
+                    let res_have = download_vec_znx::<BE>(&res_have_backend);
+
+                    // Composition: idft into BIG, small add, normalize.
+                    let a_dft = dft_of_uploaded_vec_znx(module, &a, 1, 0);
+                    let mut big = module.vec_znx_big_alloc(1, a_size);
+                    module.vec_znx_idft_apply(
+                        &mut big.to_backend_mut(),
+                        0,
+                        &a_dft.to_backend_ref(),
+                        col,
+                        &mut scratch.arena(),
+                    );
+                    if with_addend {
+                        module.vec_znx_big_add_small_assign(&mut big.to_backend_mut(), 0, &addend_ref, 0);
+                    }
+                    let mut res_want_backend = upload_vec_znx::<BE>(&res_host_template);
+                    module.vec_znx_big_normalize(
+                        &mut vec_znx_backend_mut::<BE>(&mut res_want_backend),
+                        res_base2k,
+                        0,
+                        0,
+                        &big.to_backend_ref(),
+                        base2k,
+                        0,
+                        &mut scratch.arena(),
+                    );
+                    let res_want = download_vec_znx::<BE>(&res_want_backend);
+
+                    assert_eq!(
+                        res_want, res_have,
+                        "idft_normalize_consume != idft + add_small + normalize for a_size={a_size}, res_size={res_size}, \
+                         res_base2k={res_base2k}, addend={with_addend}, col={col}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Verifies `vec_znx_idft_normalize_consume` against the composition of
+/// `vec_znx_idft_apply`, `vec_znx_big_add_small_assign` and
+/// `vec_znx_big_normalize`, on both `module_ref` and `module_test`.
+pub fn test_vec_znx_idft_normalize_consume<BR: crate::test_suite::TestBackend, BT: crate::test_suite::TestBackend>(
+    params: &TestParams,
+    module_host: &Module<HostBytesBackend>,
+    module_ref: &Module<BR>,
+    module_test: &Module<BT>,
+) where
+    Module<BR>: VecZnxDftAlloc<BR>
+        + VecZnxDftApply<BR>
+        + VecZnxIdftApply<BR>
+        + VecZnxIdftApplyTmpBytes
+        + crate::api::VecZnxIdftNormalizeConsume<BR>
+        + crate::api::VecZnxIdftNormalizeConsumeTmpBytes
+        + crate::api::VecZnxBigAddSmallAssign<BR>
+        + VecZnxBigAlloc<BR>
+        + VecZnxBigNormalize<BR>
+        + VecZnxBigNormalizeTmpBytes,
+    Module<BT>: VecZnxDftAlloc<BT>
+        + VecZnxDftApply<BT>
+        + VecZnxIdftApply<BT>
+        + VecZnxIdftApplyTmpBytes
+        + crate::api::VecZnxIdftNormalizeConsume<BT>
+        + crate::api::VecZnxIdftNormalizeConsumeTmpBytes
+        + crate::api::VecZnxBigAddSmallAssign<BT>
+        + VecZnxBigAlloc<BT>
+        + VecZnxBigNormalize<BT>
+        + VecZnxBigNormalizeTmpBytes,
+    ScratchOwned<BR>: ScratchOwnedAlloc<BR>,
+    ScratchOwned<BT>: ScratchOwnedAlloc<BT>,
+{
+    let base2k = params.base2k;
+    assert_eq!(module_ref.n(), module_test.n());
+    let cols = 2;
+
+    idft_normalize_consume_check_one_backend::<BR>(base2k, module_host, module_ref, cols);
+    idft_normalize_consume_check_one_backend::<BT>(base2k, module_host, module_test, cols);
 }


### PR DESCRIPTION
This PR provides the HAL foundation for Rayon support while keeping `poulpy-hal` independent of Rayon.

### Added
- A backend-selected `TaskExecutor` abstraction, with `SerialTaskExecutor` as the dependency-free default.
- Per-backend worker limits and stable scratch-sizing helpers.
- Fused HAL operations for:
  - constant-convolution accumulation;
  - DFT automorphism accumulation;
  - consuming IDFT with optional addition and normalization.
- Portable implementations in `poulpy-cpu-ref`.
- Parity tests for the new fused operations.

### Changed
- **Breaking:** `Backend` gains the required `TaskExecutor` associated type.
- **Breaking:** `HalConvolutionImpl` and `HalVecZnxDftImpl` gain the new fused operations.
- Existing CPU backends declare serial execution and provide the required adapters.
- Shared CPU defaults use the new execution and scratch contracts.

### Removed
- No public APIs or existing backend implementations are removed.

All execution remains serial in this PR. `poulpy-cpu-rayon` and the parallel AVX, AVX-512, and ARM backends are introduced in follow-up PRs.